### PR TITLE
Enable the new locales tool feature in sidekick

### DIFF
--- a/tools/sidekick/config.json
+++ b/tools/sidekick/config.json
@@ -37,6 +37,18 @@
       "id": "preflight",
       "environments": ["dev", "preview", "live"],
       "event": "preflight"
+    },
+    {
+      "containerId": "tools",
+      "id": "locales",
+      "title": "Locales",
+      "environments": [ "edit", "dev", "preview", "live" ],
+      "isPalette": true,
+      "passConfig": true,
+      "passReferrer": true,
+      "paletteRect": "top: auto; bottom: 25px; left: 75px; height: 388px; width: 360px;",
+      "url": "/tools/locale-nav",
+      "includePaths": [ "**.docx**" ]
     }
   ]
 }

--- a/tools/sidekick/config.json
+++ b/tools/sidekick/config.json
@@ -9,16 +9,23 @@
       "paletteRect": "top: auto; bottom: 20px; left: 20px; height: 398px; width: 360px;",
       "url": "https://main--milo--adobecom.hlx.page/tools/library",
       "includePaths": [ "**.docx**" ]
-    },    
+    },   
     {
-      "id": "translate",
-      "title": "Translate",
+      "id": "tools",
+      "title": "Tools",
+      "isContainer": true
+    }, 
+    {
+      "containerId": "tools",
+      "id": "localize",
+      "title": "Localize",
       "environments": [ "edit" ],
       "url": "https://milo.adobe.com/tools/translation/index.html",
       "passReferrer": true,
       "include_paths": [ "**.xlsx**" ]
     },
     {
+      "containerId": "tools",
       "title": "Send to CaaS",
       "id": "sendtocaas",
       "environments": ["dev","preview", "live", "prod"],
@@ -26,6 +33,7 @@
       "excludePaths": ["/tools/caas**", "*.json"]
     },
     {
+      "containerId": "tools",
       "title": "Check Schema",
       "id": "checkschema",
       "environments": ["prod"],
@@ -33,6 +41,7 @@
       "excludePaths": ["/tools**", "*.json"]
     },
     {
+      "containerId": "tools",
       "title": "Preflight",
       "id": "preflight",
       "environments": ["dev", "preview", "live"],

--- a/tools/sidekick/config.json
+++ b/tools/sidekick/config.json
@@ -7,7 +7,7 @@
       "environments": [ "edit" ],
       "isPalette": true,
       "paletteRect": "top: auto; bottom: 20px; left: 20px; height: 398px; width: 360px;",
-      "url": "https://main--milo--adobecom.hlx.page/tools/library",
+      "url": "https://milo.adobe.com/tools/library",
       "includePaths": [ "**.docx**" ]
     },   
     {
@@ -31,7 +31,7 @@
       "id": "sendtocaas",
       "environments": ["dev","preview", "live", "prod"],
       "event": "send-to-caas",
-      "excludePaths": ["/tools/caas**", "*.json"]
+      "excludePaths": ["https://milo.adobe.com/tools/caas**", "*.json"]
     },
     {
       "containerId": "tools",

--- a/tools/sidekick/config.json
+++ b/tools/sidekick/config.json
@@ -20,9 +20,10 @@
       "id": "localize",
       "title": "Localize",
       "environments": [ "edit" ],
-      "url": "https://milo.adobe.com/tools/translation/index.html",
+      "url": "https://main--milo--adobecom.hlx.page/tools/loc/index.html?project=cc--adobecom",
       "passReferrer": true,
-      "include_paths": [ "**.xlsx**" ]
+      "excludePaths": [ "/**" ],
+      "includePaths": [ "**/:x**" ]
     },
     {
       "containerId": "tools",
@@ -56,7 +57,7 @@
       "passConfig": true,
       "passReferrer": true,
       "paletteRect": "top: auto; bottom: 25px; left: 75px; height: 388px; width: 360px;",
-      "url": "/tools/locale-nav",
+      "url": "https://milo.adobe.com/tools/locale-nav",
       "includePaths": [ "**.docx**" ]
     }
   ]


### PR DESCRIPTION
This PR enables locales tool feature in sidekick. It also updates the url for send to caas and library (as in milo).

Test URLs:
NA