### PR TITLE
MWPW-127801 Adding top and bottom padding to reading-width

### DIFF
--- a/cc/styles/styles.css
+++ b/cc/styles/styles.css
@@ -10,5 +10,5 @@
  .reading-width {
   max-width: 600px;
   margin: auto;
-  padding: 0 20px;
+  padding: 20px;
 }


### PR DESCRIPTION
Adding top and bottom padding to reading-width

Resolves: [MWPW-127801](https://jira.corp.adobe.com/browse/MWPW-127801)

**Test URLs:**
- Before: https://main--cc--adobecom.hlx.page/creativecloud/design/hub/guides/add-elegance-or-vintage-flair-with-dusty-rose?martech=off
- After: https://main--cc--aishwaryamathuria.hlx.page/creativecloud/design/hub/guides/add-elegance-or-vintage-flair-with-dusty-rose?martech=off
