### PR TITLE
Update contentRoot

### DIFF
--- a/creativecloud/scripts/scripts.js
+++ b/creativecloud/scripts/scripts.js
@@ -105,7 +105,6 @@ const locales = {
 // Add any config options.
 const CONFIG = {
   codeRoot: '/creativecloud',
-  contentRoot: '/creativecloud',
   imsClientId: 'ccmilo',
   locales,
   geoRouting: 'on',


### PR DESCRIPTION
* Fix to show gnav and georouting for pages outside the creativecloud folder

Resolves: [MWPW-129577](https://jira.corp.adobe.com/browse/MWPW-129577)

**Test URLs:**
- Before: https://stage--cc--adobecom.hlx.page/products/flashplayer/?martech=off
- After: https://stage--cc--ruchika4.hlx.page/products/flashplayer/?martech=off
