### PR TITLE
Re adding contentRoot. 

### DIFF
--- a/creativecloud/scripts/scripts.js
+++ b/creativecloud/scripts/scripts.js
@@ -104,6 +104,7 @@ const locales = {
 
 // Add any config options.
 const CONFIG = {
+  contentRoot: '/creativecloud',
   codeRoot: '/creativecloud',
   imsClientId: 'ccmilo',
   locales,


### PR DESCRIPTION
* Content root is required by georouting and placeholders. Since we are not adding content in root and we have redirection added from creativecloud folder this would be required to make sure it loads these jsons from correct folder.

Resolves: [MWPW-127801](https://jira.corp.adobe.com/browse/MWPW-127801)

**Test URLs:**
- Before: https://www.stage.adobe.com/creativecloud/design/hub/guides/add-elegance-or-vintage-flair-with-dusty-rose.html?martech=off
- After: https://contentroot--cc--aishwaryamathuria.hlx.page/creativecloud/design/hub/guides/add-elegance-or-vintage-flair-with-dusty-rose?martech=off
