### PR TITLE
Adding css for fragment promotion

### DIFF
--- a/creativecloud/styles/styles.css
+++ b/creativecloud/styles/styles.css
@@ -12,3 +12,13 @@
   margin: auto;
   padding: 20px;
 }
+
+ .reading-width-footer-tag {
+  max-width: 600px;
+  margin: -20px auto;
+}
+
+ .reading-width-footer-tag > .content {
+  max-width: var(--grid-container-width);
+  margin: 0 auto;
+}


### PR DESCRIPTION
* As the promotion block is now moved outside the reading-width container the new css needs to be added to align it with the rest of the content. Adding the css for the same. 
* This will also fix the initial promotion alignment issue in resizing.

Resolves: [MWPW-NUMBER](https://jira.corp.adobe.com/browse/MWPW-NUMBER)

**Test URLs:**
- Before: https://stage--cc--adobecom.hlx.page/creativecloud/video/hub/guides/avoid-continuity-errors-in-film?martech=off
- After: https://promotionfix--cc--aishwaryamathuria.hlx.page/creativecloud/video/hub/guides/avoid-continuity-errors-in-film?milolibs=footer-fragment&martech=off
