### PR TITLE
MWPW-130232 Fixing adobecom cc IMS client ID

### DIFF
--- a/creativecloud/scripts/scripts.js
+++ b/creativecloud/scripts/scripts.js
@@ -106,7 +106,7 @@ const locales = {
 const CONFIG = {
   contentRoot: '/creativecloud',
   codeRoot: '/creativecloud',
-  imsClientId: 'ccmilo',
+  imsClientId: 'adobedotcom-cc',
   locales,
   geoRouting: 'on',
   prodDomains: ['www.adobe.com'],


### PR DESCRIPTION
* Fixing the client id of cc to access imslib.js v2

Resolves: [MWPW-130232](https://jira.corp.adobe.com/browse/MWPW-130232)

**Test URLs:**
- Before: https://stage--cc--adobecom.hlx.live/creativecloud/photography/hub/guides/urban-photoshoot-ideas/?martech=off
- After: https://stage--cc--aishwaryamathuria.hlx.live/creativecloud/photography/hub/guides/urban-photoshoot-ideas/?martech=off
