### PR TITLE
MWPW-128672 Update helix-sitemap yaml to have x-default

### DIFF
--- a/helix-sitemap.yaml
+++ b/helix-sitemap.yaml
@@ -9,6 +9,12 @@ sitemaps:
         source: /creativecloud/query-index.json
         alternate: /{path}.html
         destination: /creativecloud/sitemap.xml
+        hreflang: x-default
+        
+      en:
+        source: /creativecloud/query-index.json
+        alternate: /{path}.html
+        destination: /creativecloud/sitemap.xml
         hreflang: en-US
 
       au:


### PR DESCRIPTION
* x-default is missing form sitemap. Adding info for same.

Resolves: [MWPW-128672](https://jira.corp.adobe.com/browse/MWPW-128672)

**Test URLs:**
- Before: https://main--cc--adobecom.hlx.page/de/creativecloud/sitemap.xml
- After: https://main--cc--aishwaryamathuria.hlx.page/de/creativecloud/sitemap.xml
