### PR TITLE
Helix query fix

### DIFF
--- a/helix-sitemap.yaml
+++ b/helix-sitemap.yaml
@@ -7,13 +7,6 @@ sitemaps:
     languages:
       default:
         source: /creativecloud/query-index.json
-        alternate: /{path}.html
-        destination: /creativecloud/sitemap.xml
-        hreflang: x-default
-        
-      us:
-        source: /creativecloud/query-index.json
-        alternate: /{path}.html
         destination: /creativecloud/sitemap.xml
         hreflang: en-US
 

--- a/helix-sitemap.yaml
+++ b/helix-sitemap.yaml
@@ -9,6 +9,12 @@ sitemaps:
         source: /creativecloud/query-index.json
         alternate: /{path}.html
         destination: /creativecloud/sitemap.xml
+        hreflang: x-default
+        
+      en:
+        source: /creativecloud/query-index.json
+        alternate: /{path}.html
+        destination: /creativecloud/sitemap.xml
         hreflang: en-US
 
       au:

--- a/helix-sitemap.yaml
+++ b/helix-sitemap.yaml
@@ -11,7 +11,7 @@ sitemaps:
         destination: /creativecloud/sitemap.xml
         hreflang: x-default
         
-      en:
+      us:
         source: /creativecloud/query-index.json
         alternate: /{path}.html
         destination: /creativecloud/sitemap.xml


### PR DESCRIPTION
* Creating this PR to test if this fixes the duplicate data coming in sitemap.xml in certain scenarios (when we have 2 entries in helix-sitemap.yaml for same source and destination but different hreflang). This PR will be reverted if it doesn't fix the issue. 

Resolves: [MWPW-NUMBER](https://jira.corp.adobe.com/browse/MWPW-NUMBER)

**Test URLs:**
-Before: https://main--cc--adobecom.hlx.page/de/creativecloud/sitemap.xml
-After: https://helix-query-fix--cc--adobecom.hlx.page/de/creativecloud/sitemap.xml
