### PR TITLE
Take2: Fix for duplicate data in us sitemap

### DIFF
--- a/helix-sitemap.yaml
+++ b/helix-sitemap.yaml
@@ -7,13 +7,6 @@ sitemaps:
     languages:
       default:
         source: /creativecloud/query-index.json
-        alternate: /{path}.html
-        destination: /creativecloud/sitemap.xml
-        hreflang: x-default
-        
-      us:
-        source: /creativecloud/query-index.json
-        alternate: /{path}.html
         destination: /creativecloud/sitemap.xml
         hreflang: en-US
 

--- a/helix-sitemap.yaml
+++ b/helix-sitemap.yaml
@@ -9,6 +9,12 @@ sitemaps:
         source: /creativecloud/query-index.json
         alternate: /{path}.html
         destination: /creativecloud/sitemap.xml
+        hreflang: x-default
+        
+      en:
+        source: /creativecloud/query-index.json
+        alternate: /{path}.html
+        destination: /creativecloud/sitemap.xml
         hreflang: en-US
 
       au:

--- a/helix-sitemap.yaml
+++ b/helix-sitemap.yaml
@@ -11,7 +11,7 @@ sitemaps:
         destination: /creativecloud/sitemap.xml
         hreflang: x-default
         
-      en:
+      us:
         source: /creativecloud/query-index.json
         alternate: /{path}.html
         destination: /creativecloud/sitemap.xml

--- a/helix-sitemap.yaml
+++ b/helix-sitemap.yaml
@@ -4,8 +4,8 @@ sitemaps:
   website:
     origin: https://www.adobe.com
     lastmod: YYYY-MM-DD
+    default: en
     languages:
-      default:
         source: /creativecloud/query-index.json
         destination: /creativecloud/sitemap.xml
         hreflang: en-US


### PR DESCRIPTION
* Trying another fix for duplicate data in us sitemap. 

Resolves: [MWPW-130603](https://jira.corp.adobe.com/browse/MWPW-130603)

**Test URLs:**
- Before: https://main--cc--adobecom.hlx.page/de/creativecloud/sitemap.xml
- After: https://helix-query-fix--cc--adobecom.hlx.page/de/creativecloud/sitemap.xml
