### PR TITLE
Helix query fix: adding hreflang for default for x-default key

### DIFF
--- a/helix-sitemap.yaml
+++ b/helix-sitemap.yaml
@@ -7,13 +7,6 @@ sitemaps:
     languages:
       default:
         source: /creativecloud/query-index.json
-        alternate: /{path}.html
-        destination: /creativecloud/sitemap.xml
-        hreflang: x-default
-        
-      us:
-        source: /creativecloud/query-index.json
-        alternate: /{path}.html
         destination: /creativecloud/sitemap.xml
         hreflang: en-US
 

--- a/helix-sitemap.yaml
+++ b/helix-sitemap.yaml
@@ -4,8 +4,9 @@ sitemaps:
   website:
     origin: https://www.adobe.com
     lastmod: YYYY-MM-DD
-    default: en
+    default: us
     languages:
+      us:
         source: /creativecloud/query-index.json
         destination: /creativecloud/sitemap.xml
         hreflang: en-US

--- a/helix-sitemap.yaml
+++ b/helix-sitemap.yaml
@@ -9,6 +9,12 @@ sitemaps:
         source: /creativecloud/query-index.json
         alternate: /{path}.html
         destination: /creativecloud/sitemap.xml
+        hreflang: x-default
+        
+      en:
+        source: /creativecloud/query-index.json
+        alternate: /{path}.html
+        destination: /creativecloud/sitemap.xml
         hreflang: en-US
 
       au:

--- a/helix-sitemap.yaml
+++ b/helix-sitemap.yaml
@@ -11,7 +11,7 @@ sitemaps:
         destination: /creativecloud/sitemap.xml
         hreflang: x-default
         
-      en:
+      us:
         source: /creativecloud/query-index.json
         alternate: /{path}.html
         destination: /creativecloud/sitemap.xml

--- a/helix-sitemap.yaml
+++ b/helix-sitemap.yaml
@@ -4,8 +4,8 @@ sitemaps:
   website:
     origin: https://www.adobe.com
     lastmod: YYYY-MM-DD
+    default: en
     languages:
-      default:
         source: /creativecloud/query-index.json
         destination: /creativecloud/sitemap.xml
         hreflang: en-US

--- a/helix-sitemap.yaml
+++ b/helix-sitemap.yaml
@@ -4,10 +4,11 @@ sitemaps:
   website:
     origin: https://www.adobe.com
     lastmod: YYYY-MM-DD
-    default: us
+    default: en-US
     languages:
       us:
         source: /creativecloud/query-index.json
+        alternate: /{path}.html
         destination: /creativecloud/sitemap.xml
         hreflang: en-US
 


### PR DESCRIPTION
* Helix query fix: adding hreflang for default for x-default key

Resolves: [MWPW-128672](https://jira.corp.adobe.com/browse/MWPW-128672)

**Test URLs:**
- Before: https://main--cc--adobecom.hlx.page/creativecloud/sitemap.xml
- After: https://main--cc--aishwaryamathuria.hlx.page/creativecloud/sitemap.xml
