### PR TITLE
Helix query fix: adding hreflang for default for x-default key

### DIFF
--- a/helix-sitemap.yaml
+++ b/helix-sitemap.yaml
@@ -10,12 +10,6 @@ sitemaps:
         source: /creativecloud/query-index.json
         alternate: /{path}.html
         destination: /creativecloud/sitemap.xml
-        hreflang: x-default
-        
-      en:
-        source: /creativecloud/query-index.json
-        alternate: /{path}.html
-        destination: /creativecloud/sitemap.xml
         hreflang: en-US
 
       au:


### PR DESCRIPTION
* Helix query fix: adding hreflang for default for x-default key

Resolves: [MWPW-128672](https://jira.corp.adobe.com/browse/MWPW-128672)

Test URLs:

Before: https://main--cc--adobecom.hlx.page/creativecloud/sitemap.xml
After: https://main--cc--aishwaryamathuria.hlx.page/creativecloud/sitemap.xml