### PR TITLE
Removing feds header from 404

### DIFF
--- a/404.html
+++ b/404.html
@@ -4,7 +4,6 @@
 <head>
   <title>404</title>
   <meta name="template" content="404" />
-  <meta name="404" content="feds"/>
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <script src="/creativecloud/scripts/scripts.js" type="module"></script>
   <link rel="icon" href="data:," />


### PR DESCRIPTION
* Removing feds header form 404 as when milo central 404 change is merged in milo main branch it will break cc production 404 and will give following page https://main--cc--adobecom.hlx.live/this-doesnt-exist?milolibs=central-404
*Once all new 404 pages are authored we will add the meta tag in main

Resolves: [MWPW-130971](https://jira.corp.adobe.com/browse/MWPW-130971)

**Test URLs:**
- Before: https://main--cc--adobecom.hlx.live/this-doesnt-exist?milolibs=central-404
- After: https://404fedsheader--cc--adobecom.hlx.live/this-doesnt-exist?milolibs=central-404
