### PR TITLE
Support pdf viewer in CC

### DIFF
--- a/creativecloud/scripts/scripts.js
+++ b/creativecloud/scripts/scripts.js
@@ -115,7 +115,10 @@ const CONFIG = {
     pdfViewerReportSuite: 'adbadobenonacdcqa',
   },
   live: {
-    pdfViewerClientId: 'a26c77a2effb4c4aaa71e7c46385e0ed',
+    //feature branch
+    pdfViewerClientId: '73aed50cefdd432583c921083d2e7ede',
+    //main branch
+    //pdfViewerClientId: 'a26c77a2effb4c4aaa71e7c46385e0ed',
     pdfViewerReportSuite: 'adbadobenonacdcqa',
   },
   prod: {

--- a/creativecloud/scripts/scripts.js
+++ b/creativecloud/scripts/scripts.js
@@ -110,6 +110,23 @@ const CONFIG = {
   locales,
   geoRouting: 'on',
   prodDomains: ['www.adobe.com'],
+  local: {
+    pdfViewerClientId: '6cc88769fee749aea8aac8ca3555794c',
+    //pdfViewerReportSuite: 'adbadobedxqa',
+  },
+  stage: {
+    pdfViewerClientId: '0ec2ae23ed19462ebb358a917cdbab1e',
+    //pdfViewerReportSuite: 'adbadobedxqa',
+  },
+  live: {
+    pdfViewerClientId: '73aed50cefdd432583c921083d2e7ede',
+    //pdfViewerClientId: 'a26c77a2effb4c4aaa71e7c46385e0ed',
+    //pdfViewerReportSuite: 'adbadobedxqa',
+  },
+  prod: {
+    pdfViewerClientId: '409019ebd2d546c0be1a0b5a61fe65df',
+    //pdfViewerReportSuite: 'adbadobenonacdcprod,adbadobedxprod,adbadobeprototype',
+  },
 };
 
 // Load LCP image immediately

--- a/creativecloud/scripts/scripts.js
+++ b/creativecloud/scripts/scripts.js
@@ -110,22 +110,20 @@ const CONFIG = {
   locales,
   geoRouting: 'on',
   prodDomains: ['www.adobe.com'],
-  /*local: {
-    pdfViewerClientId: '6cc88769fee749aea8aac8ca3555794c',
-    //pdfViewerReportSuite: 'adbadobedxqa',
-  },*/
   stage: {
     pdfViewerClientId: '0ec2ae23ed19462ebb358a917cdbab1e',
-    //pdfViewerReportSuite: 'adbadobedxqa',
+    pdfViewerReportSuite: 'adbadobenonacdcqa',
   },
   live: {
+    //feature branch
     pdfViewerClientId: '73aed50cefdd432583c921083d2e7ede',
+    //main branch
     //pdfViewerClientId: 'a26c77a2effb4c4aaa71e7c46385e0ed',
-    //pdfViewerReportSuite: 'adbadobedxqa',
+    pdfViewerReportSuite: 'adbadobenonacdcqa',
   },
   prod: {
     pdfViewerClientId: '409019ebd2d546c0be1a0b5a61fe65df',
-    //pdfViewerReportSuite: 'adbadobenonacdcprod,adbadobedxprod,adbadobeprototype',
+    pdfViewerReportSuite: 'adbadobenonacdcprod',
   },
 };
 

--- a/creativecloud/scripts/scripts.js
+++ b/creativecloud/scripts/scripts.js
@@ -111,7 +111,7 @@ const CONFIG = {
   geoRouting: 'on',
   prodDomains: ['www.adobe.com'],
   stage: {
-    pdfViewerClientId: '0ec2ae23ed19462ebb358a917cdbab1e',
+    pdfViewerClientId: '8d2de6a43c194397933c3d41f6dadef5',
     pdfViewerReportSuite: 'adbadobenonacdcqa',
   },
   live: {

--- a/creativecloud/scripts/scripts.js
+++ b/creativecloud/scripts/scripts.js
@@ -115,10 +115,7 @@ const CONFIG = {
     pdfViewerReportSuite: 'adbadobenonacdcqa',
   },
   live: {
-    //feature branch
-    pdfViewerClientId: '73aed50cefdd432583c921083d2e7ede',
-    //main branch
-    //pdfViewerClientId: 'a26c77a2effb4c4aaa71e7c46385e0ed',
+    pdfViewerClientId: 'a26c77a2effb4c4aaa71e7c46385e0ed',
     pdfViewerReportSuite: 'adbadobenonacdcqa',
   },
   prod: {

--- a/creativecloud/scripts/scripts.js
+++ b/creativecloud/scripts/scripts.js
@@ -111,8 +111,7 @@ const CONFIG = {
   geoRouting: 'on',
   prodDomains: ['www.adobe.com'],
   stage: {
-    pdfViewerClientId: 'aefd029363e342a3a680b68780f1e3e7',
-    //pdfViewerClientId: '8d2de6a43c194397933c3d41f6dadef5',
+    pdfViewerClientId: '8d2de6a43c194397933c3d41f6dadef5',
     pdfViewerReportSuite: 'adbadobenonacdcqa',
   },
   live: {

--- a/creativecloud/scripts/scripts.js
+++ b/creativecloud/scripts/scripts.js
@@ -110,10 +110,10 @@ const CONFIG = {
   locales,
   geoRouting: 'on',
   prodDomains: ['www.adobe.com'],
-  local: {
+  /*local: {
     pdfViewerClientId: '6cc88769fee749aea8aac8ca3555794c',
     //pdfViewerReportSuite: 'adbadobedxqa',
-  },
+  },*/
   stage: {
     pdfViewerClientId: '0ec2ae23ed19462ebb358a917cdbab1e',
     //pdfViewerReportSuite: 'adbadobedxqa',

--- a/creativecloud/scripts/scripts.js
+++ b/creativecloud/scripts/scripts.js
@@ -111,7 +111,8 @@ const CONFIG = {
   geoRouting: 'on',
   prodDomains: ['www.adobe.com'],
   stage: {
-    pdfViewerClientId: '8d2de6a43c194397933c3d41f6dadef5',
+    pdfViewerClientId: 'aefd029363e342a3a680b68780f1e3e7',
+    //pdfViewerClientId: '8d2de6a43c194397933c3d41f6dadef5',
     pdfViewerReportSuite: 'adbadobenonacdcqa',
   },
   live: {


### PR DESCRIPTION
* Add pdf embed api support for CC pages to view the pdf on page

Resolves: [MWPW-130346](https://jira.corp.adobe.com/browse/MWPW-130346)

**Test URLs:**
- Before: https://main--cc--adobecom.hlx.page/drafts/dstrong/cors-test?martech=off
- After: https://pdf-embed-api--cc--adobecom.hlx.page/drafts/dstrong/cors-test?martech=off

Note: Credential for live in PR are for main branch. Hence to open pdf in feature branch we'll need to update the credential for feature branch in git.
