### PR TITLE
Update itef for /la geo

### DIFF
--- a/creativecloud/scripts/scripts.js
+++ b/creativecloud/scripts/scripts.js
@@ -26,7 +26,7 @@ const locales = {
   ca_fr: { ietf: 'fr-CA', tk: 'vrk5vyv.css' },
   cl: { ietf: 'es-CL', tk: 'oln4yqj.css' },
   co: { ietf: 'es-CO', tk: 'oln4yqj.css' },
-  la: { ietf: 'es-LA', tk: 'oln4yqj.css' },
+  la: { ietf: 'es-419', tk: 'oln4yqj.css' },
   mx: { ietf: 'es-MX', tk: 'oln4yqj.css' },
   pe: { ietf: 'es-PE', tk: 'oln4yqj.css' },
   '': { ietf: 'en-US', tk: 'hah7vzn.css' },


### PR DESCRIPTION
Resolves: [MWPW-133115](https://jira.corp.adobe.com/browse/MWPW-133115)

`es-LA` means "spanish-Laos". `419` is the UN M49 code for "Latinoamerica".

URL for testing:

- https://patch-1--cc--hparra--adobecom.hlx.page/