### PR TITLE
add substance3D pages to the sitemap(US only)

### DIFF
--- a/helix-query.yaml
+++ b/helix-query.yaml
@@ -10,6 +10,7 @@ indices:
       - '**/fragments/**'
     include:
       - /creativecloud/**
+      - /products/substance3d/**
     target: /cc-shared/assets/query-index.xlsx
     properties:
       title:


### PR DESCRIPTION
* Update helix query to add substance3D pages to sitemap

Resolves: [MWPW-131783](https://jira.corp.adobe.com/browse/MWPW-131783)

**Test URLs:**
NA
