### PR TITLE
Add tag selector plugin to sidekick

### DIFF
--- a/tools/sidekick/config.json
+++ b/tools/sidekick/config.json
@@ -69,6 +69,15 @@
       "paletteRect": "top: auto; bottom: 25px; left: 75px; height: 388px; width: 360px;",
       "url": "https://milo.adobe.com/tools/locale-nav",
       "includePaths": [ "**.docx**" ]
+    },
+    {
+      "containerId": "tools",
+      "title": "Tag Selector",
+      "id": "tag-selector",
+      "environments": ["edit"],
+      "url": "https://milo.adobe.com/tools/tag-selector",
+      "isPalette": true,
+      "paletteRect": "top: 150px; left: 7%; height: 675px; width: 85vw;"
     }
   ]
 }


### PR DESCRIPTION
* Add tag selector plugin to the sidekick

Resolves: [MWPW-134018](https://jira.corp.adobe.com/browse/MWPW-134018)

**Test URLs:**
- Before: https://main--cc--adobecom.hlx.page/?martech=off
- After: https://tagSelector--cc--adobecom.hlx.page/?martech=off
