### PR TITLE
update top value for tag selector plugin

### DIFF
--- a/tools/sidekick/config.json
+++ b/tools/sidekick/config.json
@@ -87,7 +87,7 @@
       "environments": ["edit"],
       "url": "https://milo.adobe.com/tools/tag-selector",
       "isPalette": true,
-      "paletteRect": "top: 150px; left: 7%; height: 675px; width: 85vw;"
+      "paletteRect": "top: 100px; left: 7%; height: 675px; width: 85vw;"
     }
   ]
 }


### PR DESCRIPTION
* fix bottom cut off issue of tag selector plugin

Resolves: [MWPW-134018](https://jira.corp.adobe.com/browse/MWPW-134018)

**Test URLs:**
- Before: https://main--cc--adobecom.hlx.page/?martech=off
- After: https://tag-selector--cc--adobecom.hlx.page/?martech=off

Note: Open the above pages in edit mode to see tag selector in plugin and see the change
