### PR TITLE
Add css for section metadata style grid width 6 for mobile and tablet

### DIFF
--- a/creativecloud/styles/styles.css
+++ b/creativecloud/styles/styles.css
@@ -24,12 +24,12 @@
   margin: 0 auto;
 }
   
- .section.grid-width-6:has(.icon-block) {
+ .section.grid-width-6 > .icon-block {
     padding-left: var(--grid-margins-width-6);
 }
 
 @media screen and (min-width: 600px) and (max-width: 1200px) {
-  .section.grid-width-6:has(.icon-block) {
+  .section.grid-width-6 > .icon-block {
     padding-left: var(--grid-margins-width-6);
     padding-right: var(--grid-margins-width-6);
   }

--- a/creativecloud/styles/styles.css
+++ b/creativecloud/styles/styles.css
@@ -23,3 +23,15 @@
   max-width: var(--grid-container-width);
   margin: 0 auto;
 }
+  
+ .section.grid-width-6:has(.icon-block) {
+    padding-left: var(--grid-margins-width-6);
+}
+
+@media screen and (min-width: 600px) and (max-width: 1200px) {
+  .section.grid-width-6:has(.icon-block) {
+    padding-left: var(--grid-margins-width-6);
+    padding-right: var(--grid-margins-width-6);
+  }
+}
+

--- a/creativecloud/styles/styles.css
+++ b/creativecloud/styles/styles.css
@@ -24,12 +24,12 @@
   margin: 0 auto;
 }
   
- .section.grid-width-6:has(icon-block) {
+ .section.grid-width-6:has(.icon-block) {
     padding-left: var(--grid-margins-width-6);
 }
 
 @media screen and (min-width: 600px) and (max-width: 1200px) {
-  .section.grid-width-6:has(icon-block) {
+  .section.grid-width-6:has(.icon-block) {
     padding-left: var(--grid-margins-width-6);
     padding-right: var(--grid-margins-width-6);
   }

--- a/creativecloud/styles/styles.css
+++ b/creativecloud/styles/styles.css
@@ -24,12 +24,12 @@
   margin: 0 auto;
 }
   
- .section.grid-width-6 > .icon-block {
+ .section.grid-width-6:has(icon-block) {
     padding-left: var(--grid-margins-width-6);
 }
 
 @media screen and (min-width: 600px) and (max-width: 1200px) {
-  .section.grid-width-6 > .icon-block {
+  .section.grid-width-6:has(icon-block) {
     padding-left: var(--grid-margins-width-6);
     padding-right: var(--grid-margins-width-6);
   }


### PR DESCRIPTION
* Add padding in mobile and tablet view when Grid Width 6 is added in section metadata 
* This css will only be applicable if section metadata has icon block

Resolves: [MWPW-136028](https://jira.corp.adobe.com/browse/MWPW-136028)

**Test URLs:**

- Before: https://stage--cc--adobecom.hlx.live/creativecloud/tools/logo-software?martech=off
- After: https://section-metadata--cc--adobecom.hlx.live/creativecloud/tools/logo-software?martech=off

Note: Please open the page in mobile and tablet view to test it and look at Ai icon section shared in the screenshot below. Attaching the expected layout which has been approved by our product owners

<img width="766" alt="Screen Shot 2023-09-06 at 10 45 57 AM" src="https://github.com/adobecom/milo/assets/69535463/f7b142b8-3b2c-4829-9d4d-359dfb577bb2">
<img width="716" alt="Screen Shot 2023-09-06 at 10 46 15 AM" src="https://github.com/adobecom/milo/assets/69535463/c6ad96de-ff49-4fc2-a4cb-cdc81a120f0f">
