### PR TITLE
Revert "disable send to caas in config"

### DIFF
--- a/tools/sidekick/config.json
+++ b/tools/sidekick/config.json
@@ -38,6 +38,14 @@
     },
     {
       "containerId": "tools",
+      "title": "Send to CaaS",
+      "id": "sendtocaas",
+      "environments": ["dev","preview", "live", "prod"],
+      "event": "send-to-caas",
+      "excludePaths": ["https://milo.adobe.com/tools/caas**", "*.json"]
+    },
+    {
+      "containerId": "tools",
       "title": "Check Schema",
       "id": "checkschema",
       "environments": ["prod"],


### PR DESCRIPTION
Reverts adobecom/cc#67
as jira ticket https://jira.corp.adobe.com/browse/MWPW-132559 is closed now and send to caas option in sidekick can be re-enabled