### PR TITLE
MWPW-134192-Add caas and faas configurator to sidekick

### DIFF
--- a/tools/sidekick/config.json
+++ b/tools/sidekick/config.json
@@ -107,6 +107,24 @@
       "url": "https://milo.adobe.com/tools/tag-selector",
       "isPalette": true,
       "paletteRect": "top: 100px; left: 7%; height: 675px; width: 85vw;"
+    },
+    {
+      "containerId": "tools",
+      "id": "caas-configurator",
+      "title": "CaaS Configurator",
+      "environments": [ "edit", "preview", "dev" ],
+      "url": "https://milo.adobe.com/tools/caas",
+      "isPalette": false,
+      "includePaths": [ "**.docx**"]
+    },
+    {
+      "containerId": "tools",
+      "id": "faas-configurator",
+      "title": "FaaS Configurator",
+      "environments": [ "edit", "preview", "dev" ],
+      "url": "https://milo.adobe.com/tools/faas",
+      "isPalette": false,
+      "includePaths": [ "**.docx**"]
     }
   ]
 }


### PR DESCRIPTION
* Add links to CaaS and FaaS configurator to the sidekick
* Link to these configurators has been added under Tools
* Configurator page will open in a new tab in browser

Resolves: [MWPW-134192](https://jira.corp.adobe.com/browse/MWPW-134192)

**Test URLs:**
- Before: https://main--cc--adobecom.hlx.page/?martech=off
- After: https://sidekick--cc--ruchika4.hlx.page/?martech=off
