### PR TITLE
MWPW-137735: update sitemap index

### DIFF
--- a/helix-query.yaml
+++ b/helix-query.yaml
@@ -10,7 +10,7 @@ indices:
       - '**/fragments/**'
     include:
       - /creativecloud/**
-      - /products/substance3d/**
+      - /products/**
     target: /cc-shared/assets/query-index.xlsx
     properties:
       title:


### PR DESCRIPTION
### Updates sitemap index to index all pages under /products.

Resolves: [MWPW-137735](https://jira.corp.adobe.com/browse/MWPW-137735)

As more and more pages located under `/products` have to go live and be a part of EDS sitemap, we decided to update index definition to include everything located under /products directory.
The same behavior is already adopted for `/creativecloud`, so it's not something new for GWP.

With this PR, all in-progress pages were moved out of `/products`. In-progress pages, that couldn't be moved out, were marked as 'no-index, no-follow', so that they don't appear in the sitemap until go live. This was done in global metadata.
Starting from now, for any newly added to `/products` page, that should not be in sitemap, 'no index, no-follow' is required.

**Test URLs:**
No before/after URLs required, since it's an index update.