### PR TITLE
changing path for images

### DIFF
--- a/creativecloud/features/changeBg/changeBg.js
+++ b/creativecloud/features/changeBg/changeBg.js
@@ -9,7 +9,7 @@ function getImageSrc(viewport, pic) {
   let imageSrc = '';
   if (viewport === 'mobile') imageSrc = pic.querySelector('source[type="image/webp"]:not([media])');
   else imageSrc = pic.querySelector('source[type="image/webp"][media]');
-  return imageSrc.srcset.replace('./', '/');
+  return imageSrc.srcset;
 }
 
 function createLayer(viewport, property, layerConfig) {


### PR DESCRIPTION
Removing the replace function so the images can take the relative path.

Resolves: [MWPW-133818](https://jira.corp.adobe.com/browse/MWPW-133818)

**Test URLs:**
- Before: https://main--cc--adobecom.hlx.page/?martech=off
- After: https://<branch>--cc--adobecom.hlx.page/?martech=off
