### PR TITLE
MWPW-140466 | Main | Add CC blocks to Sidekick block library

### DIFF
--- a/tools/sidekick/config.json
+++ b/tools/sidekick/config.json
@@ -1,5 +1,13 @@
 {
   "project": "Creative Cloud",
+  "libraries": [
+    {
+      "text": "Blocks",
+      "paths": [ "https://main--milo--adobecom.hlx.page/docs/library/blocks.json"
+                 "https://main--cc--adobecom.hlx.page/docs/library/blocks.json",
+      ]
+    }
+  ],
   "plugins": [
     {
       "id": "library",

--- a/tools/sidekick/config.json
+++ b/tools/sidekick/config.json
@@ -1,11 +1,5 @@
 {
   "project": "Creative Cloud",
-  "libraries": [
-    {
-      "text": "Blocks",
-      "paths": ["https://main--milo--adobecom.hlx.page/docs/library/blocks.json", "https://main--cc--adobecom.hlx.page/docs/library/blocks.json"]
-    }
-  ],
   "plugins": [
     {
       "id": "library",
@@ -13,7 +7,7 @@
       "environments": [ "edit" ],
       "isPalette": true,
       "paletteRect": "top: auto; bottom: 20px; left: 20px; height: 398px; width: 360px;",
-      "url": "https://milo.adobe.com/tools/library",
+      "url": "https://milo.adobe.com/tools/library?ref=main&repo=cc&owner=adobecom&host=adobe.com&project=CC",
       "includePaths": [ "**.docx**" ]
     },   
     {

--- a/tools/sidekick/config.json
+++ b/tools/sidekick/config.json
@@ -7,7 +7,7 @@
       "environments": [ "edit" ],
       "isPalette": true,
       "paletteRect": "top: auto; bottom: 20px; left: 20px; height: 398px; width: 360px;",
-      "url": "https://milo.adobe.com/tools/library",
+      "url": "https://milo.adobe.com/tools/library?ref=main&repo=cc&owner=adobecom&host=adobe.com&project=CC",
       "includePaths": [ "**.docx**" ]
     },   
     {

--- a/tools/sidekick/config.json
+++ b/tools/sidekick/config.json
@@ -3,9 +3,7 @@
   "libraries": [
     {
       "text": "Blocks",
-      "paths": [ "https://main--milo--adobecom.hlx.page/docs/library/blocks.json",
-                 "https://main--cc--adobecom.hlx.page/docs/library/blocks.json",
-      ]
+      "paths": ["https://main--milo--adobecom.hlx.page/docs/library/blocks.json", "https://main--cc--adobecom.hlx.page/docs/library/blocks.json"]
     }
   ],
   "plugins": [

--- a/tools/sidekick/config.json
+++ b/tools/sidekick/config.json
@@ -13,7 +13,7 @@
       "environments": [ "edit" ],
       "isPalette": true,
       "paletteRect": "top: auto; bottom: 20px; left: 20px; height: 398px; width: 360px;",
-      "url": "https://milo.adobe.com/tools/library?ref=main&repo=cc&owner=adobecom&host=adobe.com&project=CC",
+      "url": "https://milo.adobe.com/tools/library",
       "includePaths": [ "**.docx**" ]
     },   
     {

--- a/tools/sidekick/config.json
+++ b/tools/sidekick/config.json
@@ -3,7 +3,7 @@
   "libraries": [
     {
       "text": "Blocks",
-      "paths": [ "https://main--milo--adobecom.hlx.page/docs/library/blocks.json"
+      "paths": [ "https://main--milo--adobecom.hlx.page/docs/library/blocks.json",
                  "https://main--cc--adobecom.hlx.page/docs/library/blocks.json",
       ]
     }


### PR DESCRIPTION
New CC interactive marquee blocks are currently not visible in sidekick library. 
Updating the library url to pull cc blocks as well.

Resolves: [MWPW-140466](https://jira.corp.adobe.com/browse/MWPW-140466)

**Test URLs:**
- Before: https://milo.adobe.com/tools/library
- After: https://milo.adobe.com/tools/library?ref=main&repo=cc&owner=adobecom&host=adobe.com&project=CC