### PR TITLE
MWPW-140466 | Stage | Add CC blocks to Sidekick block library

### DIFF
--- a/tools/sidekick/config.json
+++ b/tools/sidekick/config.json
@@ -7,7 +7,7 @@
       "environments": [ "edit" ],
       "isPalette": true,
       "paletteRect": "top: auto; bottom: 20px; left: 20px; height: 398px; width: 360px;",
-      "url": "https://milo.adobe.com/tools/library",
+      "url": "https://milo.adobe.com/tools/library?ref=main&repo=cc&owner=adobecom&host=adobe.com&project=CC",
       "includePaths": [ "**.docx**" ]
     },   
     {


### PR DESCRIPTION
New CC interactive marquee blocks are currently not visible in sidekick library.
Updating the library url to pull cc blocks as well.

Resolves: [MWPW-140466](https://jira.corp.adobe.com/browse/MWPW-140466)

Test URLs:

Before: https://milo.adobe.com/tools/library
After: https://milo.adobe.com/tools/library?ref=main&repo=cc&owner=adobecom&host=adobe.com&project=CC