### PR TITLE
[MWPW-140716] Integrating virtual comments extension with CC

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -4,6 +4,7 @@
         "dbaeumer.vscode-eslint",
         "editorconfig.editorconfig",
         "ryanluker.vscode-coverage-gutters",
-        "eamodio.gitlens"
+        "eamodio.gitlens",
+        "virtual-comments.virtual-comments"
     ]
 }


### PR DESCRIPTION
* Adding the extension in the list of recommended vscode extensions
* This extension can also be found in the vscode marketplace by the id virtual-comments

Resolves: [MWPW-140716](https://jira.corp.adobe.com/browse/MWPW-140716)
