### PR TITLE
Remove out of scope geos from sitemap for batch 1C ROW

### DIFF
--- a/helix-query.yaml
+++ b/helix-query.yaml
@@ -116,30 +116,6 @@ indices:
       - /uk/creativecloud/**
     target: /uk/cc-shared/assets/query-index.xlsx
 
-  creativecloud-dk:
-    <<: *def
-    include:
-      - /dk/creativecloud/**
-    target: /dk/cc-shared/assets/query-index.xlsx
-
-  creativecloud-fi:
-    <<: *def
-    include:
-      - /fi/creativecloud/**
-    target: /fi/cc-shared/assets/query-index.xlsx
-    
-  creativecloud-no:
-    <<: *def
-    include:
-      - /no/creativecloud/**
-    target: /no/cc-shared/assets/query-index.xlsx
-
-  creativecloud-se:
-    <<: *def
-    include:
-      - /se/creativecloud/**
-    target: /se/cc-shared/assets/query-index.xlsx
-
   creativecloud-ca:
     <<: *def
     include:
@@ -151,18 +127,6 @@ indices:
     include:
       - /cn/creativecloud/**
     target: /cn/cc-shared/assets/query-index.xlsx
-
-  creativecloud-la:
-    <<: *def
-    include:
-      - /la/creativecloud/**
-    target: /la/cc-shared/assets/query-index.xlsx
-
-  creativecloud-mx:
-    <<: *def
-    include:
-      - /mx/creativecloud/**
-    target: /mx/cc-shared/assets/query-index.xlsx
 
   creativecloud-ae_ar:
     <<: *def
@@ -194,18 +158,6 @@ indices:
       - /be_fr/creativecloud/**
     target: /be_fr/cc-shared/assets/query-index.xlsx
 
-  creativecloud-be_nl:
-    <<: *def
-    include:
-      - /be_nl/creativecloud/**
-    target: /be_nl/cc-shared/assets/query-index.xlsx
-
-  creativecloud-bg:
-    <<: *def
-    include:
-      - /bg/creativecloud/**
-    target: /bg/cc-shared/assets/query-index.xlsx
-
   creativecloud-ca_fr:
     <<: *def
     include:
@@ -224,12 +176,6 @@ indices:
       - /ch_fr/creativecloud/**
     target: /ch_fr/cc-shared/assets/query-index.xlsx
 
-  creativecloud-ch_it:
-    <<: *def
-    include:
-      - /ch_it/creativecloud/**
-    target: /ch_it/cc-shared/assets/query-index.xlsx
-
   creativecloud-cl:
     <<: *def
     include:
@@ -241,18 +187,6 @@ indices:
     include:
       - /cy_en/creativecloud/**
     target: /cy_en/cc-shared/assets/query-index.xlsx
-
-  creativecloud-cz:
-    <<: *def
-    include:
-      - /cz/creativecloud/**
-    target: /cz/cc-shared/assets/query-index.xlsx
-
-  creativecloud-ee:
-    <<: *def
-    include:
-      - /ee/creativecloud/**
-    target: /ee/cc-shared/assets/query-index.xlsx  
 
   creativecloud-gr_en:
     <<: *def
@@ -266,12 +200,6 @@ indices:
       - /hk_en/creativecloud/**
     target: /hk_en/cc-shared/assets/query-index.xlsx
 
-  creativecloud-hu:
-    <<: *def
-    include:
-      - /hu/creativecloud/**
-    target: /hu/cc-shared/assets/query-index.xlsx
-
   creativecloud-ie:
     <<: *def
     include:
@@ -283,12 +211,6 @@ indices:
     include:
       - /il_en/creativecloud/**
     target: /il_en/cc-shared/assets/query-index.xlsx
-
-  creativecloud-il_he:
-    <<: *def
-    include:
-      - /il_he/creativecloud/**
-    target: /il_he/cc-shared/assets/query-index.xlsx
 
   creativecloud-in:
     <<: *def
@@ -320,12 +242,6 @@ indices:
       - /lu_fr/creativecloud/**
     target: /lu_fr/cc-shared/assets/query-index.xlsx
 
-  creativecloud-mena_ar:
-    <<: *def
-    include:
-      - /mena_ar/creativecloud/**
-    target: /mena_ar/cc-shared/assets/query-index.xlsx
-
   creativecloud-mena_en:
     <<: *def
     include:
@@ -342,19 +258,7 @@ indices:
     <<: *def
     include:
       - /nz/creativecloud/**
-    target: /nz/cc-shared/assets/query-index.xlsx  
-
-  creativecloud-pt:
-    <<: *def
-    include:
-      - /pt/creativecloud/**
-    target: /pt/cc-shared/assets/query-index.xlsx
-
-  creativecloud-ro:
-    <<: *def
-    include:
-      - /ro/creativecloud/**
-    target: /ro/cc-shared/assets/query-index.xlsx
+    target: /nz/cc-shared/assets/query-index.xlsx
 
   creativecloud-sa_ar:
     <<: *def
@@ -367,18 +271,6 @@ indices:
     include:
       - /sa_en/creativecloud/**
     target: /sa_en/cc-shared/assets/query-index.xlsx
-
-  creativecloud-si:
-    <<: *def
-    include:
-      - /si/creativecloud/**
-    target: /si/cc-shared/assets/query-index.xlsx
-
-  creativecloud-sk:
-    <<: *def
-    include:
-      - /sk/creativecloud/**
-    target: /sk/cc-shared/assets/query-index.xlsx
     
   creativecloud-th_en:
     <<: *def
@@ -391,12 +283,6 @@ indices:
     include:
       - /th_th/creativecloud/**
     target: /th_th/cc-shared/assets/query-index.xlsx
-
-  creativecloud-ua:
-    <<: *def
-    include:
-      - /ua/creativecloud/**
-    target: /ua/cc-shared/assets/query-index.xlsx
 
   creativecloud-za:
     <<: *def

--- a/helix-sitemap.yaml
+++ b/helix-sitemap.yaml
@@ -96,30 +96,6 @@ sitemaps:
         destination: /uk/cc-shared/assets/sitemap.xml
         hreflang: en-GB
 
-      dk:
-        source: /dk/cc-shared/assets/query-index.json
-        alternate: /dk/{path}.html
-        destination: /dk/cc-shared/assets/sitemap.xml
-        hreflang: da-DK
-
-      fi:
-        source: /fi/cc-shared/assets/query-index.json
-        alternate: /fi/{path}.html
-        destination: /fi/cc-shared/assets/sitemap.xml
-        hreflang: fi-FI
-
-      no:
-        source: /no/cc-shared/assets/query-index.json
-        alternate: /no/{path}.html
-        destination: /no/cc-shared/assets/sitemap.xml
-        hreflang: no-NO
-
-      se:
-        source: /se/cc-shared/assets/query-index.json
-        alternate: /se/{path}.html
-        destination: /se/cc-shared/assets/sitemap.xml
-        hreflang: sv-SE
-
       ca:
         source: /ca/cc-shared/assets/query-index.json
         alternate: /ca/{path}.html
@@ -131,21 +107,6 @@ sitemaps:
         alternate: /cn/{path}.html
         destination: /cn/cc-shared/assets/sitemap.xml
         hreflang: zh-CN
-
-      la:
-        source: /la/cc-shared/assets/query-index.json
-        alternate: /la/{path}.html
-        destination: /la/cc-shared/assets/sitemap.xml
-        hreflang:
-          - es-PA
-          - es-SV
-          - es-VE
-
-      mx:
-        source: /mx/cc-shared/assets/query-index.json
-        alternate: /mx/{path}.html
-        destination: /mx/cc-shared/assets/sitemap.xml
-        hreflang: es-MX
         
       ae_ar:
         source: /ae_ar/cc-shared/assets/query-index.json
@@ -175,19 +136,7 @@ sitemaps:
         source: /be_fr/cc-shared/assets/query-index.json
         alternate: /be_fr/{path}.html
         destination: /be_fr/cc-shared/assets/sitemap.xml
-        hreflang: fr-BE 
-
-      be_nl:
-        source: /be_nl/cc-shared/assets/query-index.json
-        alternate: /be_nl/{path}.html
-        destination: /be_nl/cc-shared/assets/sitemap.xml
-        hreflang: nl-BE 
-
-      bg:
-        source: /bg/cc-shared/assets/query-index.json
-        alternate: /bg/{path}.html
-        destination: /bg/cc-shared/assets/sitemap.xml
-        hreflang: bg-BG
+        hreflang: fr-BE
 
        ca_fr:
         source: /ca_fr/cc-shared/assets/query-index.json
@@ -207,12 +156,6 @@ sitemaps:
         destination: /ch_fr/cc-shared/assets/sitemap.xml
         hreflang: fr-CH
 
-      ch_it:
-        source: /ch_it/cc-shared/assets/query-index.json
-        alternate: /ch_it/{path}.html
-        destination: /ch_it/cc-shared/assets/sitemap.xml
-        hreflang: it-CH
-
       cl:
         source: /cl/cc-shared/assets/query-index.json
         alternate: /cl/{path}.html
@@ -225,18 +168,6 @@ sitemaps:
         destination: /cy_en/cc-shared/assets/sitemap.xml
         hreflang: en-CY
 
-      cz:
-        source: /cz/cc-shared/assets/query-index.json
-        alternate: /cz/{path}.html
-        destination: /cz/cc-shared/assets/sitemap.xml
-        hreflang: cs-CZ
-        
-      ee:
-        source: /ee/cc-shared/assets/query-index.json
-        alternate: /ee/{path}.html
-        destination: /ee/cc-shared/assets/sitemap.xml
-        hreflang: et-EE
-
       gr_en:
         source: /gr_en/cc-shared/assets/query-index.json
         alternate: /gr_en/{path}.html
@@ -248,12 +179,6 @@ sitemaps:
         alternate: /hk_en/{path}.html
         destination: /hk_en/cc-shared/assets/sitemap.xml
         hreflang: en-HK
-        
-      hu:
-        source: /hu/cc-shared/assets/query-index.json
-        alternate: /hu/{path}.html
-        destination: /hu/cc-shared/assets/sitemap.xml
-        hreflang: hu-HU
 
       ie:
         source: /ie/cc-shared/assets/query-index.json
@@ -265,13 +190,7 @@ sitemaps:
         source: /il_en/cc-shared/assets/query-index.json
         alternate: /il_en/{path}.html
         destination: /il_en/cc-shared/assets/sitemap.xml
-        hreflang: en-IL 
-
-      il_he:
-        source: /il_he/cc-shared/assets/query-index.json
-        alternate: /il_he/{path}.html
-        destination: /il_he/cc-shared/assets/sitemap.xml
-        hreflang: he-IL
+        hreflang: en-IL
 
       in:
         source: /in/cc-shared/assets/query-index.json
@@ -303,18 +222,6 @@ sitemaps:
         destination: /lu_fr/cc-shared/assets/sitemap.xml
         hreflang: fr-LU
 
-      mena_ar:
-        source: /mena_ar/cc-shared/assets/query-index.json
-        alternate: /mena_ar/{path}.html
-        destination: /mena_ar/cc-shared/assets/sitemap.xml
-        hreflang: 
-          - ar-IL
-          - ar-IQ
-          - ar-JO
-          - ar-LB
-          - ar-MA
-          - ar-OM
-
       mena_en:
         source: /mena_en/cc-shared/assets/query-index.json
         alternate: /mena_en/{path}.html
@@ -332,18 +239,6 @@ sitemaps:
         alternate: /nz/{path}.html
         destination: /nz/cc-shared/assets/sitemap.xml
         hreflang: en-NZ
-
-      pt:
-        source: /pt/cc-shared/assets/query-index.json
-        alternate: /pt/{path}.html
-        destination: /pt/cc-shared/assets/sitemap.xml
-        hreflang: pt-PT 
-
-      ro:
-        source: /ro/cc-shared/assets/query-index.json
-        alternate: /ro/{path}.html
-        destination: /ro/cc-shared/assets/sitemap.xml
-        hreflang: ro-RO
         
       sa_ar:
         source: /sa_ar/cc-shared/assets/query-index.json
@@ -355,19 +250,7 @@ sitemaps:
         source: /sa_en/cc-shared/assets/query-index.json
         alternate: /sa_en/{path}.html
         destination: /sa_en/cc-shared/assets/sitemap.xml
-        hreflang: en-SA 
-
-      si:
-        source: /si/cc-shared/assets/query-index.json
-        alternate: /si/{path}.html
-        destination: /si/cc-shared/assets/sitemap.xml
-        hreflang: sl-SI 
-
-      sk:
-        source: /sk/cc-shared/assets/query-index.json
-        alternate: /sk/{path}.html
-        destination: /sk/cc-shared/assets/sitemap.xml
-        hreflang: sk-SK
+        hreflang: en-SA
 
       th_en:
         source: /th_en/cc-shared/assets/query-index.json
@@ -380,12 +263,6 @@ sitemaps:
         alternate: /th_th/{path}.html
         destination: /th_th/cc-shared/assets/sitemap.xml
         hreflang: th-TH
-
-      ua:
-        source: /ua/cc-shared/assets/query-index.json
-        alternate: /ua/{path}.html
-        destination: /ua/cc-shared/assets/sitemap.xml
-        hreflang: uk-UA
         
       za:
         source: /za/cc-shared/assets/query-index.json


### PR DESCRIPTION
* Out of scope geos for batch 1C ROW
DK, ES, FI, IT, NL, NO, SE,  LA, MX,  BE_nl, BG,  CH_it, CZ, EE,  HU, IL_he, MENA_ar, PL, PT, RO, SI, SK,  TR, UA
* This PR removes the above geos except below as they were added as part of previous ROW release are needed for those batches
ES, IT, NL, PL, TR

Resolves: [MWPW-138378](https://jira.corp.adobe.com/browse/MWPW-138378)

**Test URLs:**
NA
