### PR TITLE
Exclude express urls from getting .html appended

### DIFF
--- a/creativecloud/scripts/scripts.js
+++ b/creativecloud/scripts/scripts.js
@@ -149,6 +149,9 @@ const CONFIG = {
     version: '1.83',
     onDemand: false,
   },
+  htmlExclude: [
+    /www\.adobe\.com\/(\w\w(_\w\w)?\/)?express(\/.*)?/,
+  ],
 };
 
 /*


### PR DESCRIPTION
* Exclude express urls from getting .html appended

Resolves: [MWPW-141730](https://jira.corp.adobe.com/browse/MWPW-141730)

**Test URLs:**
- Before: https://main--cc--adobecom.hlx.page/?martech=off
- After: https://excludehtml--cc--adobecom.hlx.page/?martech=off
