### PR TITLE
MWPW-136892: update prod domains

### DIFF
--- a/creativecloud/scripts/scripts.js
+++ b/creativecloud/scripts/scripts.js
@@ -125,7 +125,7 @@ const CONFIG = {
   imsClientId: 'adobedotcom-cc',
   locales,
   geoRouting: 'on',
-  prodDomains: ['www.adobe.com'],
+  prodDomains: ['www.adobe.com', 'helpx.adobe.com', 'business.adobe.com'],
   queryIndexCardPath: '/cc-shared/assets/query-index-cards',
   decorateArea,
   stage: {


### PR DESCRIPTION
this is going to enable generation of localised Download urls towards these domains.

e.g: https://helpx.adobe.com/download-install.html

GWP will author this in US/EN only, and it will be automatically localized by Milo.

for locales who do not have this page published,  GWP has capability to override the URL.

related to: https://github.com/adobecom/milo/pull/1739