### PR TITLE
MWPW-141962-Fix interactive marquee css issues

### DIFF
--- a/creativecloud/blocks/interactive-marquee/milo-marquee.css
+++ b/creativecloud/blocks/interactive-marquee/milo-marquee.css
@@ -27,6 +27,7 @@
 .interactive-marquee .media {
   max-width: 300px;
   position: relative;
+  padding: 0;
 }
 
 .interactive-marquee .text {

--- a/creativecloud/blocks/interactive-marquee/milo-marquee.css
+++ b/creativecloud/blocks/interactive-marquee/milo-marquee.css
@@ -60,8 +60,8 @@
 .interactive-marquee .icon-text {
   margin: auto var(--spacing-xs);
   font-weight: 700;
-  font-size: 18px;
-  line-height: 22.5px;
+  font-size: var(--type-heading-m-size);
+  line-height: var(--type-heading-m-lh);
   font-style: normal;
 }
 

--- a/creativecloud/features/firefly/firefly-interactive.css
+++ b/creativecloud/features/firefly/firefly-interactive.css
@@ -95,7 +95,7 @@
   }
 
   .interactive-marquee.firefly .foreground {
-    padding: 0;
+    padding-top: 0;
   }
 }
 
@@ -122,7 +122,7 @@
   }
 
   .interactive-marquee.firefly .foreground {
-    padding: 0;
+    padding-top: 0;
   }
 }
 

--- a/creativecloud/features/firefly/firefly-interactive.css
+++ b/creativecloud/features/firefly/firefly-interactive.css
@@ -92,7 +92,11 @@
 
   .interactive-marquee.firefly .media {
     top: 8px;
-  }  
+  }
+
+  .interactive-marquee.firefly .foreground {
+    padding: 0;
+  }
 }
 
 @media (min-width: 600px) and (max-width: 1199px) {
@@ -115,6 +119,10 @@
 
   .interactive-marquee.firefly .interactive-container {
     height: 813px;
+  }
+
+  .interactive-marquee.firefly .foreground {
+    padding: 0;
   }
 }
 


### PR DESCRIPTION
* Set padding for media in interactive marquee container to 0 so that padding set in media.css is not applied to it.
* Fix the font-size for product name and per figma
* Fix extra padding showing up only in firefly marquee in mobile and tablet which was added to interactive marquee css [here](https://github.com/adobecom/cc/pull/151/files)

Resolves: [MWPW-141962](https://jira.corp.adobe.com/browse/MWPW-141962)

**Test URLs:**
- Before: https://main--cc--adobecom.hlx.page/products/firefly?martech=off
- After: https://mwpw-141962--cc--adobecom.hlx.page/products/firefly?martech=off
