### PR TITLE
[Main]MWPW-142788-add go url to html exclude list

### DIFF
--- a/creativecloud/scripts/scripts.js
+++ b/creativecloud/scripts/scripts.js
@@ -151,6 +151,7 @@ const CONFIG = {
   },
   htmlExclude: [
     /www\.adobe\.com\/(\w\w(_\w\w)?\/)?express(\/.*)?/,
+    /www\.adobe\.com\/(\w\w(_\w\w)?\/)?go(\/.*)?/,
   ],
 };
 


### PR DESCRIPTION
* Add go urls in html exclude list

Resolves: [MWPW-142788](https://jira.corp.adobe.com/browse/MWPW-142788)

**Test URLs:**
- Before: https://main--cc--adobecom.hlx.page/?martech=off
- After: https://gourl--cc--adobecom.hlx.page/?martech=off


Note: This is a blocker issue for today's ongoing release. We need to exclude milo from appending .html for any /go/** urls