### PR TITLE
MWPW-143215 [sidenav]  make re-ordering possible with camel case

### DIFF
--- a/creativecloud/blocks/sidenav/sidenav.js
+++ b/creativecloud/blocks/sidenav/sidenav.js
@@ -5,7 +5,7 @@ import '../../deps/merch-sidenav.js';
 const CATEGORY_ID_PREFIX = 'categories/';
 const TYPE_ID_PREFIX = 'types/';
 
-const getIdLeaf = (id) => (id?.substring(id.lastIndexOf('/') + 1) || id);
+const getIdLeaf = (id) => (id?.substring(id.lastIndexOf('/') + 1) || id).toLowerCase();
 
 const getCategories = (items, isMultilevel, mapCategories) => {
   const configuration = { manageTabIndex: true };

--- a/test/blocks/sidenav/sidenav.test.html
+++ b/test/blocks/sidenav/sidenav.test.html
@@ -35,8 +35,8 @@
                 <li>Social-media</li>
                 <li>Pdf</li>
                 <li>Esignatures</li>
-                <li>Coldfusion</li>
-                <li>Elearning</li>
+                <li>ColdFusion</li>
+                <li>ELearning</li>
                 <li>Print-imaging</li>
                 <li>Technical-communication</li>
                 <li>Insight-audiences</li>

--- a/test/blocks/sidenav/sidenav.test.html.js
+++ b/test/blocks/sidenav/sidenav.test.html.js
@@ -36,6 +36,9 @@ runTests(async () => {
       expect(newRoot.title).to.equal('REFINE YOUR RESULTS');
       const items = newRoot.querySelectorAll('sp-sidenav-item');
       expect(items.length).to.equal(expectedItemCount);
+      const found = Array.from(items).find((item) => item.getAttribute('label') === 'ColdFusion');
+      expect(found).to.not.be.undefined;
+      expect(found.getAttribute('value')).to.equal('coldfusion');
       const search = newRoot.querySelector('sp-search');
       expect(search.getAttribute('placeholder')).to.equal('Search all your products');
       expect(newRoot.querySelectorAll('sp-checkbox').length).to.equal(3);
@@ -49,7 +52,9 @@ runTests(async () => {
     });
 
     it('does create nice reordered categories sidenav', async () => {
-      await testCategorySidenav('.reordered-categories', 17, 11);
+      // 16 items from html requirements, 2 parents from taxonomy,
+      // and special-offer special case is 19
+      await testCategorySidenav('.reordered-categories', 19, 13);
     });
 
     it('does create nice plans sidenav', async () => {


### PR DESCRIPTION
Resolves: [MWPW-143215](https://jira.corp.adobe.com/browse/MWPW-143215)

**Test URLs:**
- Before: https://main--cc--adobecom.hlx.page/drafts/gewittig/catalog-test?martech=off
- After: https://mwpw-143215--cc--npeltier.hlx.page/drafts/gewittig/catalog-test?martech=off
