### PR TITLE
service_providers is now optional as api_key

### DIFF
--- a/creativecloud/blocks/universal-promo-terms/universal-promo-terms.js
+++ b/creativecloud/blocks/universal-promo-terms/universal-promo-terms.js
@@ -3,6 +3,7 @@ const SELECTOR_ID_API_BASE = 'https://aos.adobe.io/offers:search.selector';
 const STAGE_OFFER_ID_API_BASE = 'https://aos-stage.adobe.io/offers/';
 const STAGE_SELECTOR_ID_API_BASE = 'https://aos-stage.adobe.io/offers:search.selector';
 const API_KEY = 'universalPromoTerm';
+const SERVICE_PROVIDERS = 'PROMO_TERMS';
 
 function getEnv(env) {
   if (env) return env;
@@ -14,13 +15,19 @@ async function getTermsHTML(params, el, env, search) {
   const locationSearch = search ?? window.location.search;
   let promoTerms;
   if (!params.get('offer_selector_ids')) {
-    const fetchURL = `${env === 'stage' ? STAGE_OFFER_ID_API_BASE : OFFER_ID_API_BASE}${params.get('offer_id')}${locationSearch}${params.get('api_key') ? '' : `&api_key=${API_KEY}`}`;
+    let fetchURL = `${env === 'stage' ? STAGE_OFFER_ID_API_BASE : OFFER_ID_API_BASE}${params.get('offer_id')}${locationSearch}`;
+    fetchURL += params.get('api_key') ? '' : `&api_key=${API_KEY}`;
+    fetchURL += params.get('service_providers') ? '' : `&service_providers=${SERVICE_PROVIDERS}`;
+
     const res = await fetch(fetchURL);
     if (!res.ok) return false;
     const json = await res.json();
     promoTerms = json[0]?.promo_terms;
   } else {
-    const fetchURL = `${env === 'stage' ? STAGE_SELECTOR_ID_API_BASE : SELECTOR_ID_API_BASE}${locationSearch}${params.get('api_key') ? '' : `&api_key=${API_KEY}`}`;
+    let fetchURL = `${env === 'stage' ? STAGE_SELECTOR_ID_API_BASE : SELECTOR_ID_API_BASE}${locationSearch}`;
+    fetchURL += params.get('api_key') ? '' : `&api_key=${API_KEY}`;
+    fetchURL += params.get('service_providers') ? '' : `&service_providers=${SERVICE_PROVIDERS}`;
+
     const res = await fetch(fetchURL);
     if (!res.ok) return false;
     const json = await res.json();

--- a/test/blocks/universal-promo-terms/universal.promo.terms.test.js
+++ b/test/blocks/universal-promo-terms/universal.promo.terms.test.js
@@ -16,7 +16,7 @@ describe('universal-promo-terms', () => {
   });
 
   it('Get API from query parameters', async () => {
-    await init(block, '?offer_selector_ids=x-TQSF1eZiZ637gnd_GgfN1c7W0Ksj2FG7gJwxCHCjY&locale=en_US&promotion_code=COM_CCSN_STOCKPD&country=CY&service_providers=PROMO_TERMS&landscape=draft&env=stage');
+    await init(block, '?offer_id=1B365A793986BBEEE26F3E372BDAAB09&locale=de_DE&promotion_code=fixed_dis_20&country=DE&env=stage');
     expect(document.querySelector('.universal-promo-terms').textContent).to.not.equal('false');
   });
 });


### PR DESCRIPTION
Resolves: [MWPW-141444](https://jira.corp.adobe.com/browse/MWPW-141444)

Josh King wants this update
<img width="444" alt="image" src="https://github.com/adobecom/cc/assets/55804872/ec29b954-6d9f-49f4-8538-50753add5252">


**Test URLs:**
- Before: https://stage--cc--adobecom.hlx.live/creativecloud/offers/promo-terms?offer_id=1B365A793986BBEEE26F3E372BDAAB09&country=DE&locale=de_DE&promotion_code=fixed_dis_20&martech=off
- After: https://universal-promo-terms--cc--adobecom.hlx.live/creativecloud/offers/promo-terms?offer_id=1B365A793986BBEEE26F3E372BDAAB09&country=DE&locale=de_DE&promotion_code=fixed_dis_20&martech=off