### PR TITLE
MWPW-143533-Handle css for 2 values in selector tray

### DIFF
--- a/creativecloud/features/firefly/firefly-interactive.css
+++ b/creativecloud/features/firefly/firefly-interactive.css
@@ -79,11 +79,16 @@
 
 @media (max-width: 600px) {
   .firefly-selectortray {
-    min-width: 110%;
-    margin-inline: -22px 16px;
     justify-content: center;
     margin-top: -7px;
     margin-bottom: 24px;
+    width: 80%;
+    margin-inline-start: 20px;
+  }
+
+  .firefly-selectortray.three-options {
+    width: 110%;
+    margin-inline: -22px 16px;
   }
 
   .interactive-marquee.firefly .interactive-container {
@@ -118,6 +123,11 @@
 
   .firefly-selectortray {
     top: 0;
+    width: 50%;
+    margin-inline: 126px;
+  }
+
+  .firefly-selectortray.three-options {
     margin-inline: 42px;
     width: 80%;
   }
@@ -138,9 +148,13 @@
 
 @media screen and (min-width: 1200px) {
   .firefly-selectortray {
-    top: 144px;
+    top: 187px;
     position: absolute;
     right: -122px;
+  }
+
+  .firefly-selectortray.three-options {
+    top: 144px;
   }
 
   [dir="rtl"] .firefly-selectortray {

--- a/creativecloud/features/firefly/firefly-interactive.js
+++ b/creativecloud/features/firefly/firefly-interactive.js
@@ -176,10 +176,11 @@ export default async function setInteractiveFirefly(el) {
   const teOption = media.querySelector('.TextEffects');
   const firstOption = media.querySelector('.selector-tray > button');
   hideRemoveElements(firstOption, media, mediaP);
-  const genfillPrompt = createGenFillPrompt(genfDetail.promptpos, createTag);
+
   // Create prompt field for first option on page load
   const firstOptionDetail = allP[3].innerText.split('|');
-  const fireflyPrompt = await createPromptField(`${firstOptionDetail[0]}`, `${firstOptionDetail[1]}`, interactiveElemMode);
+  const mode = firstOption.classList.contains('GenerativeFill') ? 'genfill' : interactiveElemMode;
+  const fireflyPrompt = await createPromptField(`${firstOptionDetail[0]}`, `${firstOptionDetail[1]}`, mode);
   if (firstOption.classList.contains('TextToImage') || firstOption.classList.contains('TextEffects')) {
     fireflyPrompt.classList.add('firefly-prompt');
     media.appendChild(fireflyPrompt);
@@ -187,6 +188,7 @@ export default async function setInteractiveFirefly(el) {
     eventOnGenerate(generateButton, media);
   } else if (firstOption.classList.contains('GenerativeFill')) {
     fireflyPrompt.classList.add('genfill-promptbar');
+    const genfillPrompt = createGenFillPrompt(genfDetail.promptpos, createTag);
     media.append(genfillPrompt, fireflyPrompt);
     const genFillButton = media.querySelector('#genfill');
     genFillButton.addEventListener('click', async () => {
@@ -201,6 +203,7 @@ export default async function setInteractiveFirefly(el) {
   });
   genFillOption?.addEventListener('click', () => {
     eventOnSelectorOption(genFillOption, genfDetail, media, mediaP, createPromptField);
+    const genfillPrompt = createGenFillPrompt(genfDetail.promptpos, createTag);
     media.appendChild(genfillPrompt);
   });
   teOption?.addEventListener('click', () => {

--- a/creativecloud/features/firefly/firefly-interactive.js
+++ b/creativecloud/features/firefly/firefly-interactive.js
@@ -169,6 +169,7 @@ export default async function setInteractiveFirefly(el) {
   }
   const fireflyOptions = await createSelectorTray(selections, interactiveElemMode);
   fireflyOptions.classList.add('firefly-selectortray');
+  if (selections.length === 3) fireflyOptions.classList.add('three-options');
   media.append(fireflyOptions);
   const ttiOption = media.querySelector('.TextToImage');
   const genFillOption = media.querySelector('.GenerativeFill');
@@ -195,14 +196,14 @@ export default async function setInteractiveFirefly(el) {
   }
   focusOnInput(media, createTag);
   /* Handle action on click of each firefly option button */
-  ttiOption.addEventListener('click', () => {
+  ttiOption?.addEventListener('click', () => {
     eventOnSelectorOption(ttiOption, ttiDetail, media, mediaP, createPromptField, createTag);
   });
-  genFillOption.addEventListener('click', () => {
+  genFillOption?.addEventListener('click', () => {
     eventOnSelectorOption(genFillOption, genfDetail, media, mediaP, createPromptField);
     media.appendChild(genfillPrompt);
   });
-  teOption.addEventListener('click', () => {
+  teOption?.addEventListener('click', () => {
     eventOnSelectorOption(teOption, teDetail, media, mediaP, createPromptField, createTag);
   });
 }


### PR DESCRIPTION
* Handle css for 2 values in selector tray

Resolves: [MWPW-143533](https://jira.corp.adobe.com/browse/MWPW-143533)

**Test URLs:**
2 options in selector tray:
- Before: https://main--cc--adobecom.hlx.live/drafts/ruchika/firefly/remove-dnt/document2?martech=off
- After: https://selector-tray--cc--adobecom.hlx.live/drafts/ruchika/firefly/remove-dnt/document2?martech=off

3 options in selector tray:
- Before: https://main--cc--adobecom.hlx.live/drafts/ruchika/firefly/remove-dnt/document1?martech=off
- After: https://selector-tray--cc--adobecom.hlx.live/drafts/ruchika/firefly/remove-dnt/document1?martech=off

No change in UI for 3 options in selector tray

