### PR TITLE
MWPW-143426 fixing sidenav parents when implicitly declared

### DIFF
--- a/creativecloud/blocks/sidenav/sidenav.js
+++ b/creativecloud/blocks/sidenav/sidenav.js
@@ -13,7 +13,6 @@ const getCategories = (items, isMultilevel, mapCategories) => {
     configuration.variant = 'multilevel';
   }
   const mapParents = {};
-  const implicitParents = [];
   const sidenav = createTag('sp-sidenav', configuration);
   const merchTag = createTag('merch-sidenav-list', { deeplink: 'category' });
   merchTag.append(sidenav);

--- a/creativecloud/blocks/sidenav/sidenav.js
+++ b/creativecloud/blocks/sidenav/sidenav.js
@@ -12,28 +12,29 @@ const getCategories = (items, isMultilevel, mapCategories) => {
   if (isMultilevel) {
     configuration.variant = 'multilevel';
   }
-  const mapParents = [];
-  const tag = createTag('sp-sidenav', configuration);
+  const mapParents = {};
+  const implicitParents = [];
+  const sidenav = createTag('sp-sidenav', configuration);
   const merchTag = createTag('merch-sidenav-list', { deeplink: 'category' });
-  merchTag.append(tag);
+  merchTag.append(sidenav);
   items.forEach((item) => {
     if (item) {
-      let parent = tag;
+      let parent = sidenav;
       const value = getIdLeaf(item.id);
       // first token is type, second is parent category
       const isParent = item.id.split('/').length <= 2;
       const itemTag = createTag('sp-sidenav-item', { label: item.name, value });
       if (isParent) {
         mapParents[value] = itemTag;
-        tag.append(itemTag);
+        sidenav.append(itemTag);
       } else {
         const parentId = getIdLeaf(item.id.substring(0, item.id.lastIndexOf('/')));
         if (isMultilevel) {
           if (!mapParents[parentId]) {
             const parentItem = mapCategories[parentId];
             if (parentItem) {
-              mapParents[parentId] = createTag('sp-sidenav-item', { label: parentItem.name, parentId });
-              tag.append(mapParents[parentId]);
+              mapParents[parentId] = createTag('sp-sidenav-item', { label: parentItem.name, value: parentId });
+              implicitParents.push(mapParents[parentId]);
             }
           }
           parent = mapParents[parentId];
@@ -42,6 +43,9 @@ const getCategories = (items, isMultilevel, mapCategories) => {
       }
     }
   });
+  if (implicitParents.length > 0) {
+    implicitParents.forEach((item) => sidenav.append(item));
+  }
   return merchTag;
 };
 

--- a/creativecloud/blocks/sidenav/sidenav.js
+++ b/creativecloud/blocks/sidenav/sidenav.js
@@ -34,7 +34,7 @@ const getCategories = (items, isMultilevel, mapCategories) => {
             const parentItem = mapCategories[parentId];
             if (parentItem) {
               mapParents[parentId] = createTag('sp-sidenav-item', { label: parentItem.name, value: parentId });
-              implicitParents.push(mapParents[parentId]);
+              sidenav.append(mapParents[parentId]);
             }
           }
           parent = mapParents[parentId];
@@ -43,9 +43,6 @@ const getCategories = (items, isMultilevel, mapCategories) => {
       }
     }
   });
-  if (implicitParents.length > 0) {
-    implicitParents.forEach((item) => sidenav.append(item));
-  }
   return merchTag;
 };
 

--- a/creativecloud/blocks/sidenav/sidenav.js
+++ b/creativecloud/blocks/sidenav/sidenav.js
@@ -140,7 +140,7 @@ export default async function init(el) {
     import(`${libs}/features/spectrum-web-components/dist/dialog.js`),
   ]);
 
-  const title = el.querySelector('h2')?.textContent.trim();
+  const title = el.querySelector('h2,h3')?.textContent.trim();
   const rootNav = createTag('merch-sidenav', { title });
   const searchText = el.querySelector('p > strong')?.textContent.trim();
   const typeText = el.querySelector('p > em')?.textContent.trim();

--- a/test/blocks/sidenav/sidenav.test.html
+++ b/test/blocks/sidenav/sidenav.test.html
@@ -50,6 +50,21 @@
             </div>
           </div>
         </div>
+        <div class="sidenav parent-generation">
+          <div>
+            <div>
+              <h2 id="refine-your-results">REFINE YOUR RESULTS</h2>
+              <p><strong>Search all your products</strong></p>
+              <p><a href="/some/taxonomy.json">https://www.adobe.com/some/taxonomy.json</a></p>
+              <ul>
+                <li>all</li>
+                <li>ColdFusion</li>
+                <li>Graphic-design</li>
+                <li>pdf-esignatures</li>
+              </ul>
+            </div>
+          </div>
+        </div>
         <div class="sidenav plans">
           <div>
             <div>

--- a/test/blocks/sidenav/sidenav.test.html
+++ b/test/blocks/sidenav/sidenav.test.html
@@ -13,7 +13,7 @@
         <div class="sidenav categories">
           <div>
             <div>
-              <h2 id="refine-your-results">REFINE YOUR RESULTS</h2>
+              <h3 id="refine-your-results">REFINE YOUR RESULTS</h3>
               <p><strong>Search all your products</strong></p>
               <p><a href="/some/taxonomy.json">https://www.adobe.com/some/taxonomy.json</a></p>
               <p><em>TYPES</em></p>
@@ -24,7 +24,7 @@
         <div class="sidenav reordered-categories">
           <div>
             <div>
-              <h2 id="refine-your-results">REFINE YOUR RESULTS</h2>
+              <h3 id="refine-your-results">REFINE YOUR RESULTS</h3>
               <p><strong>Search all your products</strong></p>
               <p><a href="/some/taxonomy.json">https://www.adobe.com/some/taxonomy.json</a></p>
               <ul>
@@ -53,7 +53,7 @@
         <div class="sidenav parent-generation">
           <div>
             <div>
-              <h2 id="refine-your-results">REFINE YOUR RESULTS</h2>
+              <h3 id="refine-your-results">REFINE YOUR RESULTS</h3>
               <p><strong>Search all your products</strong></p>
               <p><a href="/some/taxonomy.json">https://www.adobe.com/some/taxonomy.json</a></p>
               <ul>
@@ -68,7 +68,7 @@
         <div class="sidenav plans">
           <div>
             <div>
-              <h2>REFINE YOUR RESULTS</h2>
+              <h3>REFINE YOUR RESULTS</h3>
               <p><a href="/some/taxonomy.json">https://www.adobe.com//some/taxonomy.json</a></p>
               <ul>
                 <li>All</li>

--- a/test/blocks/sidenav/sidenav.test.html
+++ b/test/blocks/sidenav/sidenav.test.html
@@ -50,7 +50,7 @@
             </div>
           </div>
         </div>
-        <div class="sidenav parent-generation">
+        <div class="sidenav parent-reordered">
           <div>
             <div>
               <h3 id="refine-your-results">REFINE YOUR RESULTS</h3>
@@ -59,8 +59,8 @@
               <ul>
                 <li>all</li>
                 <li>ColdFusion</li>
-                <li>Graphic-design</li>
-                <li>pdf-esignatures</li>
+                <li>pdf-esignatures</li>              
+                <li>graphic-design</li>
               </ul>
             </div>
           </div>

--- a/test/blocks/sidenav/sidenav.test.html.js
+++ b/test/blocks/sidenav/sidenav.test.html.js
@@ -29,7 +29,13 @@ runTests(async () => {
       window.fetch = sinon.stub().callsFake(() => mockedTaxonomy());
     });
 
-    const testCategorySidenav = async (selector, expectedItemCount, expectedChildItemCount) => {
+    const testCategorySidenav = async (
+      selector,
+      expectedItemCount,
+      expectedParentCount,
+      expectedChildItemCount,
+      expectedCheckboxCount = 3,
+    ) => {
       const sidenavEl = document.querySelector(selector);
       const newRoot = await init(sidenavEl);
       expect(newRoot.tagName).to.equal('MERCH-SIDENAV');
@@ -41,20 +47,31 @@ runTests(async () => {
       expect(found.getAttribute('value')).to.equal('coldfusion');
       const search = newRoot.querySelector('sp-search');
       expect(search.getAttribute('placeholder')).to.equal('Search all your products');
-      expect(newRoot.querySelectorAll('sp-checkbox').length).to.equal(3);
+      expect(newRoot.querySelectorAll('sp-checkbox').length).to.equal(expectedCheckboxCount);
+      if (expectedCheckboxCount > 0) {
+        expect(newRoot.querySelector('sp-checkbox').textContent.trim()).to.equal('Desktop');
+      }
+      const parents = newRoot.querySelectorAll('sp-sidenav > sp-sidenav-item');
+      expect(parents.length).to.equal(expectedParentCount);
       const nestedItems = newRoot.querySelectorAll('sp-sidenav-item > sp-sidenav-item');
       expect(nestedItems.length).to.equal(expectedChildItemCount);
-      expect(newRoot.querySelector('sp-checkbox').textContent.trim()).to.equal('Desktop');
+      return newRoot;
     };
 
     it('does create nice categories default sidenav', async () => {
-      await testCategorySidenav('.categories', 24, 18);
+      await testCategorySidenav('.categories', 24, 6, 18);
     });
 
     it('does create nice reordered categories sidenav', async () => {
       // 16 items from html requirements, 2 parents from taxonomy,
       // and special-offer special case is 19
-      await testCategorySidenav('.reordered-categories', 19, 13);
+      await testCategorySidenav('.reordered-categories', 19, 6, 13);
+    });
+
+    it('does put implicit at last position', async () => {
+      const root = await testCategorySidenav('.parent-generation', 6, 4, 2, 0);
+      const parents = root.querySelectorAll('sp-sidenav > sp-sidenav-item');
+      expect(parents[parents.length - 1].getAttribute('value')).to.equal('creativity-design');
     });
 
     it('does create nice plans sidenav', async () => {

--- a/test/blocks/sidenav/sidenav.test.html.js
+++ b/test/blocks/sidenav/sidenav.test.html.js
@@ -68,7 +68,7 @@ runTests(async () => {
       await testCategorySidenav('.reordered-categories', 19, 6, 13);
     });
 
-    it('does put implicit at last position', async () => {
+    it('when a parent is added implicitly (no parent explicitly configured, just its children), does push it to last position', async () => {
       const root = await testCategorySidenav('.parent-generation', 6, 4, 2, 0);
       const parents = root.querySelectorAll('sp-sidenav > sp-sidenav-item');
       expect(parents[parents.length - 1].getAttribute('value')).to.equal('creativity-design');

--- a/test/blocks/sidenav/sidenav.test.html.js
+++ b/test/blocks/sidenav/sidenav.test.html.js
@@ -68,8 +68,8 @@ runTests(async () => {
       await testCategorySidenav('.reordered-categories', 19, 6, 13);
     });
 
-    it('when a parent is added implicitly (no parent explicitly configured, just its children), does push it to last position', async () => {
-      const root = await testCategorySidenav('.parent-generation', 6, 4, 2, 0);
+    it('parents should be re-orderable as well', async () => {
+      const root = await testCategorySidenav('.parent-reordered', 6, 4, 2, 0);
       const parents = root.querySelectorAll('sp-sidenav > sp-sidenav-item');
       expect(parents[parents.length - 1].getAttribute('value')).to.equal('creativity-design');
     });


### PR DESCRIPTION
when parents are auto-generated, they don't work well (no value => no unfold, no filtering)

Resolves: [MWPW-143426](https://jira.corp.adobe.com/browse/MWPW-143426)

**Test URLs:**
- Before: https://main--cc--adobecom.hlx.page/drafts/npeltier/catalog?martech=off
- After: https://mwpw-143426--cc--npeltier.hlx.page/drafts/npeltier/catalog?martech=off
