### PR TITLE
MWPW-143472 | clientId for pdfviewer updated

### DIFF
--- a/creativecloud/scripts/scripts.js
+++ b/creativecloud/scripts/scripts.js
@@ -133,7 +133,7 @@ const CONFIG = {
   stage: {
     marTechUrl: 'https://assets.adobedtm.com/d4d114c60e50/a0e989131fd5/launch-2c94beadc94f-development.min.js',
     edgeConfigId: '8d2805dd-85bf-4748-82eb-f99fdad117a6',
-    pdfViewerClientId: '8d2de6a43c194397933c3d41f6dadef5',
+    pdfViewerClientId: '9f7f19a46bd542e2b8548411e51eb4d4',
     pdfViewerReportSuite: 'adbadobenonacdcqa',
   },
   live: {


### PR DESCRIPTION
ClientId updated for stage.adobe.com

Resolves: [MWPW-143472](https://jira.corp.adobe.com/browse/MWPW-143472)

Test URLs:

Before: https://www.stage.adobe.com/creativecloud/business/teams/resources/sdk/computer-sas-industry-insights.html?martech=off
After: https://mwpw-143472--cc--sharath-kannan.hlx.page/?martech=off
The test url given above is just a placeholder as the clientid is picked based on the domain,I have tested the clientID at runtime in the browser.
