### PR TITLE
MWPW-143057-Remove mt and cy_en from CC sitemap

### DIFF
--- a/creativecloud/sitemap-index.xml
+++ b/creativecloud/sitemap-index.xml
@@ -76,9 +76,6 @@
     <loc>https://www.adobe.com/cl/cc-shared/assets/sitemap.xml</loc>
   </sitemap>
   <sitemap>
-    <loc>https://www.adobe.com/cy_en/cc-shared/assets/sitemap.xml</loc>
-  </sitemap>
-  <sitemap>
     <loc>https://www.adobe.com/gr_en/cc-shared/assets/sitemap.xml</loc>
   </sitemap>
   <sitemap>
@@ -110,9 +107,6 @@
   </sitemap>
   <sitemap>
     <loc>https://www.adobe.com/lu_en/cc-shared/assets/sitemap.xml</loc>
-  </sitemap>
-  <sitemap>
-    <loc>https://www.adobe.com/mt/cc-shared/assets/sitemap.xml</loc>
   </sitemap>
   <sitemap>
     <loc>https://www.adobe.com/sa_ar/cc-shared/assets/sitemap.xml</loc>

--- a/helix-query.yaml
+++ b/helix-query.yaml
@@ -381,19 +381,6 @@ indices:
       - /cl/cc-shared/fragments/merch/**/merch-card/**
     target: /cl/cc-shared/assets/query-index-cards.xslx
 
-  creativecloud-cy_en:
-    <<: *def
-    include:
-      - /cy_en/creativecloud/**
-      - /cy_en/products/**
-    target: /cy_en/cc-shared/assets/query-index.xlsx
-
-  cards-cy_en:
-    <<: *merch-cards
-    include:
-      - /cy_en/cc-shared/fragments/merch/**/merch-card/**
-    target: /cy_en/cc-shared/assets/query-index-cards.xslx
-
   creativecloud-gr_en:
     <<: *def
     include:
@@ -523,19 +510,6 @@ indices:
     include:
       - /mena_en/cc-shared/fragments/merch/**/merch-card/**
     target: /mena_en/cc-shared/assets/query-index-cards.xslx
-
-  creativecloud-mt:
-    <<: *def
-    include:
-      - /mt/creativecloud/**
-      - /mt/products/**
-    target: /mt/cc-shared/assets/query-index.xlsx  
-
-  cards-mt:
-    <<: *merch-cards
-    include:
-      - /mt/cc-shared/fragments/merch/**/merch-card/**
-    target: /mt/cc-shared/assets/query-index-cards.xslx
 
   creativecloud-nz:
     <<: *def

--- a/helix-sitemap.yaml
+++ b/helix-sitemap.yaml
@@ -162,12 +162,6 @@ sitemaps:
         destination: /cl/cc-shared/assets/sitemap.xml
         hreflang: es-CL
 
-      cy_en:
-        source: /cy_en/cc-shared/assets/query-index.json
-        alternate: /cy_en/{path}.html
-        destination: /cy_en/cc-shared/assets/sitemap.xml
-        hreflang: en-CY
-
       gr_en:
         source: /gr_en/cc-shared/assets/query-index.json
         alternate: /gr_en/{path}.html
@@ -227,12 +221,6 @@ sitemaps:
         alternate: /mena_en/{path}.html
         destination: /mena_en/cc-shared/assets/sitemap.xml
         hreflang: en-DZ
-
-      mt:
-        source: /mt/cc-shared/assets/query-index.json
-        alternate: /mt/{path}.html
-        destination: /mt/cc-shared/assets/sitemap.xml
-        hreflang: en-MT
         
       nz:
         source: /nz/cc-shared/assets/query-index.json


### PR DESCRIPTION
* Remove mt and cy_en from CC sitemap

Resolves: [MWPW-143057](https://jira.corp.adobe.com/browse/MWPW-143057)

**Test URLs:**
- Before: https://main--cc--adobecom.hlx.page/creativecloud/sitemap-index.xml
- After: https://sitemap-update--cc--adobecom.hlx.page/creativecloud/sitemap-index.xml
