### PR TITLE
MWPW-144005 For testing handle preview events from helix admin api

### DIFF
--- a/.github/workflows/log-previews.yml
+++ b/.github/workflows/log-previews.yml
@@ -1,0 +1,13 @@
+name: Test Previews
+
+on: 
+  repository_dispatch:
+    types:
+      - resources-previewed
+      - resources-unpreviewed
+jobs:
+  print:
+    runs-on: ubuntu-latest
+    steps:
+    - run: |
+        echo "Path: ${{ github.event.client_payload.paths }}"


### PR DESCRIPTION
Add git action for testing bulk preview logs in default branch. 

This is only for stage and will be reverted.

Resolves: [MWPW-144005](https://jira.corp.adobe.com/browse/MWPW-144005)

**Test URLs:**
- Before: https://main--cc--adobecom.hlx.page/?martech=off
- After: https://test-preview--cc--adobecom.hlx.page/?martech=off
