### PR TITLE
MWPW-144525 | Fixing the code coverage plugin path

### DIFF
--- a/codecov.yaml
+++ b/codecov.yaml
@@ -1,0 +1,10 @@
+coverage:
+  status: 
+    patch:
+      default:
+        target: 100%
+        threshold: 0.1%
+    project:
+      default:
+        target: auto
+        threshold: 0.1%

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@adobecom/cc",
   "private": true,
   "version": "1.0.0",
-  "description": "Website foundation technology.",
+  "description": "Adobe Creative Cloud",
   "scripts": {
     "test": "wtr --config ./web-test-runner.config.mjs \"./test/**/*.test.(js|html)\" --node-resolve --port=2000 --coverage",
     "test:watch": "npm test -- --watch",
@@ -15,14 +15,14 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/adobecom/college.git"
+    "url": "git+https://github.com/adobecom/cc.git"
   },
   "author": "Adobe",
   "license": "Apache License 2.0",
   "bugs": {
-    "url": "https://github.com/adobecom/college/issues"
+    "url": "https://github.com/adobecom/cc/issues"
   },
-  "homepage": "https://github.com/adobecom/college#readme",
+  "homepage": "https://github.com/adobecom/cc#readme",
   "devDependencies": {
     "@babel/core": "7.17.7",
     "@babel/eslint-parser": "7.17.0",

--- a/web-test-runner.config.mjs
+++ b/web-test-runner.config.mjs
@@ -33,8 +33,8 @@ const swcImportMaps = Object.fromEntries([
 
 export default {
   coverageConfig: {
-    include: ['src/**'],
-    exclude: ['test/mocks/**', 'test/**', '**/node_modules/**'],
+    include: ['creativecloud/**'],
+    exclude: ['test/mocks/**', 'test/**', '**/node_modules/**', 'creativecloud/deps/**'],
   },
   debug: false,
   files: ['test/**/*.test.(js|html)'],


### PR DESCRIPTION
Fixing the code coverage plugin path

Stage PR: https://github.com/adobecom/cc/pull/229
Resolves: [MWPW-144525](https://jira.corp.adobe.com/browse/MWPW-144525)

Test URLs:
Before: https://main--cc--adobecom.hlx.live/?martech=off
After: https://codecov--cc--aishwaryamathuria.hlx.live/?martech=off