### PR TITLE
MWPW-142148 allow icons in sidenav

### DIFF
--- a/test/blocks/sidenav/mocks/blah.svg
+++ b/test/blocks/sidenav/mocks/blah.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" height="18" viewBox="0 0 18 18" width="18">
+  <defs>
+    <style>
+      .fill {
+        fill: #464646;
+      }
+    </style>
+  </defs>
+  <title>S Apps 18 N</title>
+  <rect id="Canvas" fill="#ff13dc" opacity="0" width="18" height="18" /><rect class="fill" height="3" rx="0.5" width="3" x="1" y="1" />
+  <rect class="fill" height="3" rx="0.5" width="3" x="7" y="1" />
+</svg>

--- a/test/blocks/sidenav/sidenav.test.html
+++ b/test/blocks/sidenav/sidenav.test.html
@@ -53,18 +53,22 @@
         <div class="sidenav plans">
           <div>
             <div>
-              <h2>REFINE YOUR RESULTS</h2>
-              <p><a href="/some/taxonomy.json">https://www.adobe.com//some/taxonomy.json</a></p>
-              <ul>
-                <li>All</li>
-                <li>Photo</li>
-                <li>Graphic-design</li>
-                <li>Video</li>
-                <li>Illustration</li>
-                <li>Acrobat-pdf</li>
-                <li>3d-ar</li>
-                <li>Social-media</li>
-              </ul>
+              <h2>CATEGORIES</h2>
+            </div>
+          </div>
+          <div>
+              <div>
+                <p><a href="/some/taxonomy.json">https://www.adobe.com//some/taxonomy.json</a></p>
+                <ul>
+                  <li>All <picture><img loading="lazy" src="mocks/blah.svg"></picture></li>
+                  <li>Photo</li>
+                  <li>Graphic-design</li>
+                  <li>Video</li>
+                  <li>Illustration</li>
+                  <li>Acrobat-pdf</li>
+                  <li>3d-ar</li>
+                  <li>Social-media</li>
+                </ul>
             </div>
           </div>
         </div>

--- a/test/blocks/sidenav/sidenav.test.html.js
+++ b/test/blocks/sidenav/sidenav.test.html.js
@@ -61,11 +61,14 @@ runTests(async () => {
       const sidenavEl = document.querySelector('.plans');
       const newRoot = await init(sidenavEl);
       expect(newRoot.tagName).to.equal('MERCH-SIDENAV');
-      expect(newRoot.title).to.equal('REFINE YOUR RESULTS');
+      expect(newRoot.title).to.equal('CATEGORIES');
       const search = newRoot.querySelector('sp-search');
       expect(search).to.be.null;
       const nestedItems = newRoot.querySelectorAll('sp-sidenav-item > sp-sidenav-item');
       expect(nestedItems.length).to.equal(0);
+      const iconItem = newRoot.querySelector('sp-sidenav-item[value=all] > picture');
+      expect(iconItem).to.not.be.null;
+      expect(iconItem.getAttribute('slot')).to.equal('icon');
     });
   });
 });


### PR DESCRIPTION
<img width="263" alt="image" src="https://github.com/adobecom/cc/assets/1032754/f474d63a-78f2-4af4-9ce9-eb9af7c15065">

Resolves: [MWPW-142148](https://jira.corp.adobe.com/browse/MWPW-142148)

(sorry for .page URLs, but assets are published on main branch)

**Test URLs:**
- Before: https://main--cc--adobecom.hlx.page/drafts/npeltier/sidenav-test-icons
- After: https://mwpw-142148--cc--npeltier.hlx.page/drafts/npeltier/sidenav-test-icons
