### PR TITLE
[MWPW-145840] Enticement position is not proper for RTL locale in page and fragment -- fixed

### DIFF
--- a/creativecloud/features/genfill/genfill-interactive.css
+++ b/creativecloud/features/genfill/genfill-interactive.css
@@ -70,6 +70,13 @@
   [dir="rtl"] .enticement-text {
     position: absolute;
     left: var(--spacing-xxs);
+    right: var(--spacing-xxs);
+    margin: 40px -20px 16px 0;
+  }
+
+  [dir="rtl"] .enticement-arrow {
+    right: -54px;
+    transform: scaleX(-1); 
   }
 }
 
@@ -91,5 +98,12 @@
   [dir="rtl"] .enticement-text {
     position: absolute;
     left: var(--spacing-xxs);
+    right: var(--spacing-xxs);
+    margin: 40px -20px 16px 0;
+  }
+
+  [dir="rtl"] .enticement-arrow {
+    right: -54px;
+    transform: scaleX(-1); 
   }
 }


### PR DESCRIPTION
* Fixed the enticement position in genfill interactive marquees for RTL locale in page and fragment.

Resolves: [MWPW-145840](https://jira.corp.adobe.com/browse/MWPW-145840)

**Test URLs:**
- Before: https://main--cc--adobecom.hlx.live/drafts/drashti/bugs/genfill/document
- After: https://genfill-stage--cc--adobecom.hlx.live/drafts/drashti/bugs/genfill/document
