### PR TITLE
[Release] Sync main from stage 2/4/2024

### DIFF
--- a/tools/sidekick/config.json
+++ b/tools/sidekick/config.json
@@ -135,6 +135,13 @@
       "url": "https://milo.adobe.com/tools/faas",
       "isPalette": false,
       "includePaths": [ "**.docx**"]
+    },
+    {
+      "containerId": "tools",
+      "id": "bulk",
+      "title": "Bulk operations",
+      "environments": [ "edit", "dev", "preview", "live" ],
+      "url": "https://main--cc--adobecom.hlx.page/tools/bulk-publish"
     }
   ]
 }


### PR DESCRIPTION
Syncing following PR from stage to Main

- https://github.com/adobecom/cc/pull/258
- https://github.com/adobecom/cc/pull/260

**Test URLs:**
- Before: https://main--cc--adobecom.hlx.live/?martech=off
- After: https://stage--cc--adobecom.hlx.live/?martech=off
