### PR TITLE
MWPW-147501 | Changing CSS for blue focus line to cover the whole div

### DIFF
--- a/creativecloud/features/interactive-components/selector-tray/selector-tray.css
+++ b/creativecloud/features/interactive-components/selector-tray/selector-tray.css
@@ -57,6 +57,7 @@
 
 .interactive-enabled .step-selector-tray .selector-tray .tray-items a.tray-thumbnail-img .tray-thumbnail-outline {
   display: none;
+  box-sizing: content-box;
   height: calc(100% - 10px);
   width: calc(100% - 10px);
   border: 5px solid var(--prompt-highlight-color);


### PR DESCRIPTION
* Changing CSS for blue focus line to cover the whole div

Resolves: [MWPW-147501](https://jira.corp.adobe.com/browse/MWPW-147501)

**Test URLs:**
- Before: https://main--cc--adobecom.hlx.live/products/photoshop/explore/?martech=off
- After: https://mwpw-147501--cc--adobecom.hlx.live/products/photoshop/explore?martech=off
