### PR TITLE
MWPW-146794 | Avoid CLS due to image

### DIFF
--- a/creativecloud/blocks/interactive-marquee/milo-marquee.css
+++ b/creativecloud/blocks/interactive-marquee/milo-marquee.css
@@ -74,6 +74,7 @@
 .interactive-marquee .icon-area img {
   height: 40px;
   width: auto;
+  min-width: 40px;
   display: block;
 }
 

--- a/creativecloud/blocks/interactive-marquee/milo-marquee.css
+++ b/creativecloud/blocks/interactive-marquee/milo-marquee.css
@@ -74,7 +74,7 @@
 .interactive-marquee .icon-area img {
   height: 40px;
   width: auto;
-  min-width: 40px; 
+  min-width: 40px;
   display: block;
 }
 

--- a/creativecloud/blocks/interactive-marquee/milo-marquee.css
+++ b/creativecloud/blocks/interactive-marquee/milo-marquee.css
@@ -74,7 +74,7 @@
 .interactive-marquee .icon-area img {
   height: 40px;
   width: auto;
-  min-width: 40px;
+  min-width: 40px; 
   display: block;
 }
 


### PR DESCRIPTION
* Prevent CLS in interactive marquee when icon and text is configured side by side

<img width="300" alt="Screenshot 2024-04-30 at 11 37 15 PM" src="https://github.com/adobecom/cc/assets/9293441/3b82b463-8e92-417c-8a4f-045d04d8308b">     
<img width="300" alt="Screenshot 2024-04-30 at 11 37 30 PM" src="https://github.com/adobecom/cc/assets/9293441/e756b7a9-b9b4-4033-a710-2c4ae1a998b0">

Resolves: [MWPW-146794](https://jira.corp.adobe.com/browse/MWPW-146794) [MWPW-146757](https://jira.corp.adobe.com/browse/MWPW-146757)

**Test URLs:**
- Before: https://main--cc--adobecom.hlx.live/drafts/mathuria/interactiveelems/interactive-firefly?martech=off&georouting=off
- After: https://mwpw-146757--cc--adobecom.hlx.live/drafts/mathuria/interactiveelems/interactive-firefly?martech=off&georouting=off
