### PR TITLE
fix(MWPW-147654): make catalog buttons more square

### DIFF
--- a/creativecloud/deps/merch-sidenav.js
+++ b/creativecloud/deps/merch-sidenav.js
@@ -1,4 +1,4 @@
-// Thu, 21 Mar 2024 10:55:19 GMT
+// branch: develop commit: 369516f3cda51fb1219ad0b3cf2c94c8f094c49b Tue, 07 May 2024 11:55:00 GMT
 
 // src/sidenav/merch-sidenav.js
 import { html as html4, css as css5, LitElement as LitElement4 } from "/libs/deps/lit-all.min.js";
@@ -345,7 +345,7 @@ customElements.define(
 
 // src/media.js
 var SPECTRUM_MOBILE_LANDSCAPE = "(max-width: 700px)";
-var TABLET_DOWN = "(max-width: 1200px)";
+var TABLET_DOWN = "(max-width: 1199px)";
 
 // src/sidenav/merch-sidenav.js
 var MerchSideNav = class extends LitElement4 {
@@ -365,6 +365,7 @@ var MerchSideNav = class extends LitElement4 {
             :host {
                 display: block;
                 max-width: 248px;
+                --mod-button-border-radius: 5px;
             }
 
             #sidenav {


### PR DESCRIPTION
The button style change can be tested only via the catalog page on mobile <=700px

at https://mwpw-147654--cc--yesil.hlx.live/drafts/ilyas/catalog

1. Toggle the mobile emulator
2. Select iphone
3. Click "Filters"

Expected:
![image](https://github.com/adobecom/cc/assets/330057/ca82a495-f4dc-434c-9937-081a55191322)


Resolves: [MWPW-147654](https://jira.corp.adobe.com/browse/MWPW-147654)

**Test URLs:**
- Before: https://main--cc--adobecom.hlx.live/drafts/ilyas/fragments/sidenav?martech=off
- After: https://mwpw-147654--cc--yesil.hlx.live/drafts/ilyas/fragments/sidenav?martech=off
