### PR TITLE
MWPW-148165: continue to photoshop button is not seen working in stage ,proxy denied error is seen

### DIFF
--- a/creativecloud/scripts/scripts.js
+++ b/creativecloud/scripts/scripts.js
@@ -134,7 +134,7 @@ const CONFIG = {
     edgeConfigId: '8d2805dd-85bf-4748-82eb-f99fdad117a6',
     pdfViewerClientId: '9f7f19a46bd542e2b8548411e51eb4d4',
     pdfViewerReportSuite: 'adbadobenonacdcqa',
-    psUrl: 'https://dev.photoshop.adobe.com',
+    psUrl: 'https://stage.photoshop.adobe.com',
   },
   live: {
     pdfViewerClientId: 'a26c77a2effb4c4aaa71e7c46385e0ed',


### PR DESCRIPTION
Continue to photoshop button is not seen working in stage ,proxy denied error is seen. Thus changed the dev env to stage.

Resolves: [MWPW-148165](https://jira.corp.adobe.com/browse/MWPW-NUMBER)

**Test URLs:**
- Before:https://main--cc--adobecom.hlx.page/drafts/suhjain/interactive-marquee/continuetops
- After: https://mwpw-148165--cc--adobecom.hlx.live/drafts/suhjain/interactive-marquee/continuetops
