### PR TITLE
[MWPW-147521] interactive marquee container is not seen displayed as expected with resize flow

### DIFF
--- a/creativecloud/blocks/interactive-marquee/milo-marquee.css
+++ b/creativecloud/blocks/interactive-marquee/milo-marquee.css
@@ -176,10 +176,12 @@
     flex-direction: row;
     align-items: center;
     order: unset;
-    width: 100%;
+    width: var(--grid-container-width);
   }
 
   .interactive-marquee .interactive-container {
+    position: absolute;
+    right: 0;
     order: unset;
     width: 50%;
     height: 100%;
@@ -196,10 +198,10 @@
   }
 
   .interactive-marquee .text {
-    padding: var(--spacing-xl) 0;
     order: unset;
     display: block;
     max-width: 500px;
+    margin: 0;
   }
 }
 

--- a/creativecloud/features/firefly/firefly-interactive.css
+++ b/creativecloud/features/firefly/firefly-interactive.css
@@ -173,7 +173,7 @@
 
 @media screen and (min-width: 1200px) and (max-width: 1300px) {
   .firefly-prompt {
-    margin-inline: 18px;
+    margin-inline: 14px;
     padding-inline: 30px 7px;
   } 
 }

--- a/creativecloud/features/firefly/firefly-interactive.css
+++ b/creativecloud/features/firefly/firefly-interactive.css
@@ -170,6 +170,14 @@
   }
 }
 
+
+@media screen and (min-width: 1200px) and (max-width: 1300px) {
+  .firefly-prompt {
+    margin-inline: 18px;
+    padding-inline: 30px 7px;
+  } 
+}
+
 @media screen and (max-width: 1799px) and (min-width: 1650px) {
   .firefly-selectortray {
     right: -85px;

--- a/creativecloud/features/genfill/genfill-interactive.css
+++ b/creativecloud/features/genfill/genfill-interactive.css
@@ -107,3 +107,10 @@
     transform: scaleX(-1); 
   }
 }
+
+@media screen and (min-width: 1200px) and (max-width: 1350px) {
+  .enticement-arrow {
+    right: 0;
+    left: -55px;
+  }
+}

--- a/creativecloud/features/interactive-elements/interactive-elements.css
+++ b/creativecloud/features/interactive-elements/interactive-elements.css
@@ -347,3 +347,10 @@
     padding: 7px 18px 8px;
   }
 }
+
+@media screen and (min-width: 1200px) and (max-width: 1350px) {
+  .enticement-arrow {
+    right: 0;
+    left: -55px;
+  }
+}


### PR DESCRIPTION
* Fixes the foreground container width of the interactive marquee so that the text does not touch the edge of the screen on lower desktop screen sizes
* Also fixes the generate prompt for firefly interactive marquee, which was going out of the image for screen size > 1200px and < 1300px.

Resolves: [MWPW-147521](https://jira.corp.adobe.com/browse/MWPW-147521)

**Test URLs:**
- Before: https://main--cc--adobecom.hlx.live/docs/library/kitchen-sink/interactive-marquee?martech=off
- After: https://int-fix--cc--drashti1712.hlx.live/drafts/drashti/bugs/interactive-marquee?martech=off
