### PR TITLE
Save primary product metadata to session storage

### DIFF
--- a/creativecloud/scripts/utils.js
+++ b/creativecloud/scripts/utils.js
@@ -100,9 +100,21 @@ function getDecorateAreaFn() {
     }
   }
 
+  async function savePrimaryProduct() {
+    const LAST_PRIMARY_PRODUCT = 'last_primary_product';
+    const { getMetadata } = await import(`${getLibs()}/utils/utils.js`);
+    const primaryProduct = getMetadata('primaryproduct');
+    if (primaryProduct) {
+      window.sessionStorage.setItem(LAST_PRIMARY_PRODUCT, primaryProduct);
+    } else {
+      window.sessionStorage.removeItem(LAST_PRIMARY_PRODUCT);
+    }
+  }
+
   return (area, options) => {
     replaceDotMedia();
     if (!lcpImgSet) loadLCPImage(area, options);
+    savePrimaryProduct();
   };
 }
 

--- a/test/scripts/mocks/meta.html
+++ b/test/scripts/mocks/meta.html
@@ -1,0 +1,2 @@
+<title>test metadata</title>
+<meta name="primaryproduct" content="photoshop" />

--- a/test/scripts/mocks/nometa.html
+++ b/test/scripts/mocks/nometa.html
@@ -1,0 +1,1 @@
+<title>test without metadata</title>

--- a/test/scripts/primary-product.test.js
+++ b/test/scripts/primary-product.test.js
@@ -15,7 +15,7 @@ describe('Scripts for existing meta', () => {
 
 describe('Scripts for non-existing meta', () => {
   before(async () => {
-    window.sessionStorage.setItem('last_primary_product', 'photoshop')
+    window.sessionStorage.setItem('last_primary_product', 'photoshop');
     document.head.innerHTML = await readFile({ path: './mocks/nometa.html' });
     decorateArea();
   });

--- a/test/scripts/primary-product.test.js
+++ b/test/scripts/primary-product.test.js
@@ -1,0 +1,26 @@
+import { readFile } from '@web/test-runner-commands';
+import { expect } from '@esm-bundle/chai';
+import { decorateArea } from '../../creativecloud/scripts/utils.js';
+
+describe('Scripts for existing meta', () => {
+  before(async () => {
+    document.head.innerHTML = await readFile({ path: './mocks/meta.html' });
+    decorateArea();
+  });
+
+  it('Read last product from session storage', () => {
+    expect(window.sessionStorage.getItem('last_primary_product')).to.equal('photoshop');
+  });
+});
+
+describe('Scripts for non-existing meta', () => {
+  before(async () => {
+    window.sessionStorage.setItem('last_primary_product', 'photoshop')
+    document.head.innerHTML = await readFile({ path: './mocks/nometa.html' });
+    decorateArea();
+  });
+
+  it('Remove last product from session storage', async () => {
+    expect(window.sessionStorage.getItem('last_primary_product')).to.be.null;
+  });
+});


### PR DESCRIPTION
Some product pages will have the primary product name in page metadata 
`<meta name="primaryproduct" content="photoshop" />`
If it exists it needs to be saved in sessionStorage under the key `last_primary_product`.
If it doesn't exist in metadata it should be removed from sessionStorage.
This value in sessionStorage will be used on Plans page if Plans page is opened after the product page.
The identical feature will be added to Hawks product pages soon.

Resolves: [MWPW-148048](https://jira.corp.adobe.com/browse/MWPW-148048)

**Test URLs:**
- Before: https://main--cc--adobecom.hlx.page/products/photoshop
- After: https://mwpw148048--cc--bozojovicic.hlx.page/drafts/bozo/photoshop
