### PR TITLE
140115 - Adding a workflow for sending release notes to the Slack change-log channel

### DIFF
--- a/.github/workflows/merged-to-main.yaml
+++ b/.github/workflows/merged-to-main.yaml
@@ -1,0 +1,80 @@
+name: Merged to Main
+
+on:
+  # Triggered when a pull request is closed and merged into the main branch
+  pull_request:
+    branches:
+      - main
+    types:
+      - closed
+  # Manually triggered workflow with inputs for title and body
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'PR Number'
+        default: '200'
+        required: true
+      title:
+        description: 'Title for the PR'
+        default: 'TEST | [Release] Stage to Main'
+        required: true
+      body:
+        type: string
+        description: 'Description for the PR'
+        default: 'TEST | Description of the *PR*'
+        required: true
+
+env:
+  # Slack webhook secret
+  CC_SLACK_WEBHOOK: ${{ secrets.CC_RELEASE_SLACK_WH }}
+
+jobs:
+  # Job to handle merged pull requests
+  merged_to_main:
+    runs-on: ubuntu-latest
+    # Run the job when a pull request is merged into main and not triggered manually
+    if: ${{ github.event_name != 'workflow_dispatch' && github.event.pull_request.merged }}
+    environment: cc_pr_merge
+    env:
+      # Environment variable to store pull request details
+      EVENT_PR: ${{ toJson(github.event.pull_request) }}
+    steps:
+      # Checkout repository action
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      # Sending release notes to cc-changelog channel
+      - name: Sending Release Notes to cc-changelog slack channel
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const sendSlackMessage = require('./.github/workflows/src/send-slack.js')
+            sendSlackMessage(process.env.EVENT_PR,process.env.CC_SLACK_WEBHOOK)
+  # Job to handle manually triggered workflow_dispatch events
+  workflow_dispatch_event:
+    runs-on: ubuntu-latest
+    environment:
+      name: cc_pr_merge
+    # Run the job when the workflow is manually triggered
+    if: ${{ github.event_name == 'workflow_dispatch' }}
+    steps:
+      # Checkout repository action
+      - name: Check repository
+        uses: actions/checkout@v4
+      # Sending release notes to cc-changelog channel
+      - name: Sending Release Notes to cc-changelog slack channel
+        uses: actions/github-script@v7
+        # Set environment variables for repository URL, PR number,PR title, and PR description
+        env:
+          REPO_URL: ${{github.event.repository.html_url}}
+          PR_NUMBER: ${{github.event.inputs.pr_number}}
+          PR_TITLE: ${{github.event.inputs.title}}
+          PR_DESC: ${{github.event.inputs.body}}
+        with:
+          script: |
+            const {sendReleaseNotes} = require('./.github/workflows/src/send-slack.js')
+            sendReleaseNotes(JSON.stringify({
+              number:process.env.PR_NUMBER, 
+              html_url:process.env.REPO_URL+"/pull/"+process.env.PR_NUMBER, 
+              title:process.env.PR_TITLE, 
+              body:process.env.PR_DESC
+            }),process.env.CC_SLACK_WEBHOOK)

--- a/.github/workflows/merged-to-main.yaml
+++ b/.github/workflows/merged-to-main.yaml
@@ -2,11 +2,9 @@ name: Merged to Main
 
 on:
   # Triggered when a pull request is closed and merged into the main branch
-  pull_request:
+  push:
     branches:
-      - main
-    types:
-      - closed
+      - mwpw-140115
   # Manually triggered workflow with inputs for title and body
   workflow_dispatch:
     inputs:

--- a/.github/workflows/merged-to-main.yaml
+++ b/.github/workflows/merged-to-main.yaml
@@ -4,7 +4,7 @@ on:
   # Triggered when a pull request is closed and merged into the main branch
   pull_request:
     branches:
-      - main
+      - test-ghwf-release_notes
     types:
       - closed
   # Manually triggered workflow with inputs for title and body

--- a/.github/workflows/merged-to-main.yaml
+++ b/.github/workflows/merged-to-main.yaml
@@ -2,9 +2,11 @@ name: Merged to Main
 
 on:
   # Triggered when a pull request is closed and merged into the main branch
-  push:
+  pull_request:
     branches:
-      - mwpw-140115
+      - main
+    types:
+      - closed
   # Manually triggered workflow with inputs for title and body
   workflow_dispatch:
     inputs:

--- a/.github/workflows/src/helpers.js
+++ b/.github/workflows/src/helpers.js
@@ -1,0 +1,36 @@
+/**
+ * Function to convert Markdown text to Slack format
+ * @param {string} markdown - Markdown text to be converted
+ * @returns {string} - Converted Slack-formatted text
+ */
+function convertMarkdownToSlackFormat(markdown) {
+  // Need to fix Italic regex
+  // markdown = markdown.replace(/\*(.*?)\*/gim, "_$1_");
+
+  // Convert bold text to slack format
+  markdown = markdown.replace(/\*\*(.*?)\*\*/gim, "*$1*");
+
+  // Convert inline code to slack format
+  markdown = markdown.replace(/`([^`]+)`/g, "```$1```");
+
+  // Convert block quotes to slack format
+  markdown = markdown.replace(/^> (.*$)/gim, "_$1_");
+
+  // Convert unordered lists to slack format
+  markdown = markdown.replace(/^\s*[-+*]\s+(.*$)/gim, "\t• $1");
+
+  // Convert ordered lists to slack format
+  markdown = markdown.replace(/^\s*\d+\.\s+(.*$)/gim, "\t1. $1");
+
+  // Convert headings to slack format
+  markdown = markdown.replace(/^(#+) (.*$)/gim, "*$2*");
+
+  // Convert newlines to break lines to slack format
+  markdown = markdown.replace(/\n/g, "\n");
+
+  return markdown.trim();
+}
+
+module.exports = {
+  convertMarkdownToSlackFormat,
+};

--- a/.github/workflows/src/send-slack.js
+++ b/.github/workflows/src/send-slack.js
@@ -1,0 +1,38 @@
+const { convertMarkdownToSlackFormat } = require('./helpers');
+
+/**
+ * Function to send Slack message
+ * @param {string} pr_event - JSON string containing pull request details
+ * @param {string} slack_webhook_url - Slack webhook URL
+ * @returns {Promise} - Promise representing the result of the Slack message sending process
+ */
+const sendReleaseNotes = async (pr_event, slack_webhook_url) => {
+  pr_event = JSON.parse(pr_event);
+  const { number, html_url, title, body } = pr_event;
+
+  console.log({
+    number,
+    html_url,
+    title,
+    body,
+  });
+
+  // Format message text for Slack
+  const text = `\n
+:rocket: *Production Release*\n\n
+*TITLE:* ${title} | <${html_url}|#${number}>\n
+*PR DESCRIPTION:*\n ${convertMarkdownToSlackFormat(body)}
+`;
+
+  console.log('slack text', text);
+
+  // Send message to Slack webhook
+  const result = await fetch(slack_webhook_url, {
+    method: 'POST',
+    body: JSON.stringify({ text }),
+  }).catch(console.error);
+
+  return result;
+};
+
+module.exports = { sendReleaseNotes };


### PR DESCRIPTION
* Added workflow to send **release notes** to Slack **cc-changelog** channel when **PR** is **merged** with **main** branch
* This workflow will be triggered once the PR is merged in main branch

Resolves: [MWPW-140115](https://jira.corp.adobe.com/browse/MWPW-140115)

Note: No impact on cc pages

**Test URLs:**
- Before: https://main--cc--adobecom.hlx.live/?martech=off
- After: https://mwpw-140115--cc--sivasadobe.hlx.live/?martech=off
