### PR TITLE
Update config.json

### DIFF
--- a/tools/sidekick/config.json
+++ b/tools/sidekick/config.json
@@ -2,6 +2,17 @@
   "project": "Creative Cloud",
   "plugins": [
     {
+      "id": "path",
+      "title": "Path",
+      "environments": [ "edit" ],
+      "url": "https://milo.adobe.com/tools/path-finder",
+      "isPalette": true,
+      "passReferrer": true,
+      "passConfig": true,
+      "paletteRect": "top: 50%; left: 50%; transform: translate(-50%,-50%); height: 84px; width: 900px; overflow: hidden; border-radius: 6px; box-shadow: 0 20px 35px 0px rgba(0, 0, 0, 0.5);",
+      "includePaths": [ "**.docx**", "**.xlsx**" ]
+    },
+    {
       "id": "library",
       "title": "Library",
       "environments": [ "edit" ],

--- a/tools/sidekick/config.json
+++ b/tools/sidekick/config.json
@@ -5,7 +5,7 @@
       "id": "path",
       "title": "Path",
       "environments": [ "edit" ],
-      "url": "https://milo.adobe.com/tools/path-finder",
+      "url": "https://main--cc--adobecom.hlx.live/tools/path-finder",
       "isPalette": true,
       "passReferrer": true,
       "passConfig": true,

--- a/tools/sidekick/config.json
+++ b/tools/sidekick/config.json
@@ -5,7 +5,7 @@
       "id": "path",
       "title": "Path",
       "environments": [ "edit" ],
-      "url": "https://main--cc--adobecom.hlx.live/tools/path-finder",
+      "url": "https://milo.adobe.com/tools/path-finder",
       "isPalette": true,
       "passReferrer": true,
       "passConfig": true,


### PR DESCRIPTION
Add path finder tool to sidekick.

* Adding path finder tool to sidekick.

**Test URLs:**
- Before: https://main--cc--adobecom.hlx.live/careers?martech=off
- After: https://rgclayton-path-finder--cc--adobecom.hlx.live/careers?martech=off

Added to Milo this week.

1. Access from any Word/Excel page.
2. Open sidekick
3. Click "path" button in sidekick (top level).
4. Launches the path tool.
5. Lists the relative (human readable) path for the Word/Excel doc.
6. Can modify the path to jump to a new Word/Excel doc.
7. Options include opening the path in same page or in a new tab

![image](https://github.com/adobecom/bacom/assets/2539954/ca553e14-0bc8-4fae-93e7-d85061d128b2)