### PR TITLE
MWPW-147716: Disabled background scroll for filter dialog

### DIFF
--- a/creativecloud/deps/merch-sidenav.js
+++ b/creativecloud/deps/merch-sidenav.js
@@ -1,4 +1,4 @@
-// branch: mwpw-147716-scroll-refactoring commit: 5de8d51df428ceec0bd48fb5035badc195351405 Fri, 28 Jun 2024 13:16:59 GMT
+// branch: main commit: d113c9c27640ef88ab28eff3ef4637919479e540 Wed, 03 Jul 2024 15:04:49 GMT
 
 // src/sidenav/merch-sidenav.js
 import { html as html4, css as css5, LitElement as LitElement4 } from "/libs/deps/lit-all.min.js";
@@ -384,13 +384,13 @@ var SPECTRUM_MOBILE_LANDSCAPE = "(max-width: 700px)";
 var TABLET_DOWN = "(max-width: 1199px)";
 
 // src/bodyScrollLock.js
-var IS_IOS = /iP(ad|hone|od)/.test(window?.navigator?.platform) || window?.navigator?.platform === "MacIntel" && window.navigator.maxTouchPoints > 1;
+var isIosDevice = /iP(ad|hone|od)/.test(window?.navigator?.platform) || window?.navigator?.platform === "MacIntel" && window.navigator.maxTouchPoints > 1;
 var documentListenerAdded = false;
 var previousBodyOverflowSetting;
 var disableBodyScroll = (targetElement) => {
   if (!targetElement)
     return;
-  if (IS_IOS) {
+  if (isIosDevice) {
     document.body.style.position = "fixed";
     targetElement.ontouchmove = (event) => {
       if (event.targetTouches.length === 1) {
@@ -409,7 +409,7 @@ var disableBodyScroll = (targetElement) => {
 var enableBodyScroll = (targetElement) => {
   if (!targetElement)
     return;
-  if (IS_IOS) {
+  if (isIosDevice) {
     targetElement.ontouchstart = null;
     targetElement.ontouchmove = null;
     document.body.style.position = "";

--- a/creativecloud/deps/merch-sidenav.js
+++ b/creativecloud/deps/merch-sidenav.js
@@ -1,9 +1,9 @@
-// branch: catalog-regressions-4 commit: 90641e42ad012c2386133cbd2df855f468842b2d Wed, 29 May 2024 12:05:08 GMT
+// branch: main commit: 5a7dcb9a751bfa0d049a3f63e708e60c1e02f896 Thu, 27 Jun 2024 12:48:17 GMT
 
 // src/sidenav/merch-sidenav.js
 import { html as html4, css as css5, LitElement as LitElement4 } from "/libs/deps/lit-all.min.js";
 
-// ../../node_modules/@spectrum-web-components/reactive-controllers/src/MatchMedia.js
+// ../node_modules/@spectrum-web-components/reactive-controllers/src/MatchMedia.js
 var MatchMediaController = class {
   constructor(e, t) {
     this.key = Symbol("match-media-key");
@@ -78,6 +78,8 @@ function pushState(state) {
 }
 function deeplink(callback) {
   const handler = () => {
+    if (!window.location.hash.includes("="))
+      return;
     const state = parseState(window.location.hash);
     callback(state);
   };
@@ -381,6 +383,46 @@ customElements.define(
 var SPECTRUM_MOBILE_LANDSCAPE = "(max-width: 700px)";
 var TABLET_DOWN = "(max-width: 1199px)";
 
+// src/bodyScrollLock.js
+var isIosDevice = typeof window !== "undefined" && window.navigator && window.navigator.platform && (/iP(ad|hone|od)/.test(window.navigator.platform) || window.navigator.platform === "MacIntel" && window.navigator.maxTouchPoints > 1);
+var documentListenerAdded = false;
+var previousBodyOverflowSetting;
+var disableBodyScroll = (targetElement) => {
+  if (!targetElement)
+    return;
+  if (isIosDevice) {
+    document.body.style.position = "fixed";
+    targetElement.ontouchmove = (event) => {
+      if (event.targetTouches.length === 1) {
+        event.stopPropagation();
+      }
+    };
+    if (!documentListenerAdded) {
+      document.addEventListener("touchmove", (e) => e.preventDefault());
+      documentListenerAdded = true;
+    }
+  } else {
+    previousBodyOverflowSetting = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+  }
+};
+var enableBodyScroll = (targetElement) => {
+  if (!targetElement)
+    return;
+  if (isIosDevice) {
+    targetElement.ontouchstart = null;
+    targetElement.ontouchmove = null;
+    document.body.style.position = "";
+    document.removeEventListener("touchmove", (e) => e.preventDefault());
+    documentListenerAdded = false;
+  } else {
+    if (previousBodyOverflowSetting !== void 0) {
+      document.body.style.overflow = previousBodyOverflowSetting;
+      previousBodyOverflowSetting = void 0;
+    }
+  }
+};
+
 // src/sidenav/merch-sidenav.js
 document.addEventListener("sp-opened", () => {
   document.body.classList.add("merch-modal");
@@ -504,6 +546,7 @@ var MerchSideNav = class extends LitElement4 {
   }
   openModal() {
     this.updateComplete.then(async () => {
+      disableBodyScroll(this.dialog);
       const options = {
         trigger: this.#target,
         notImmediatelyClosable: true,
@@ -515,6 +558,7 @@ var MerchSideNav = class extends LitElement4 {
       );
       overlay.addEventListener("close", () => {
         this.modal = false;
+        enableBodyScroll(this.dialog);
       });
       this.shadowRoot.querySelector("sp-theme").append(overlay);
     });

--- a/creativecloud/deps/merch-sidenav.js
+++ b/creativecloud/deps/merch-sidenav.js
@@ -1,4 +1,4 @@
-// branch: main commit: 5a7dcb9a751bfa0d049a3f63e708e60c1e02f896 Thu, 27 Jun 2024 12:48:17 GMT
+// branch: mwpw-147716-scroll-refactoring commit: 5de8d51df428ceec0bd48fb5035badc195351405 Fri, 28 Jun 2024 13:16:59 GMT
 
 // src/sidenav/merch-sidenav.js
 import { html as html4, css as css5, LitElement as LitElement4 } from "/libs/deps/lit-all.min.js";
@@ -384,13 +384,13 @@ var SPECTRUM_MOBILE_LANDSCAPE = "(max-width: 700px)";
 var TABLET_DOWN = "(max-width: 1199px)";
 
 // src/bodyScrollLock.js
-var isIosDevice = typeof window !== "undefined" && window.navigator && window.navigator.platform && (/iP(ad|hone|od)/.test(window.navigator.platform) || window.navigator.platform === "MacIntel" && window.navigator.maxTouchPoints > 1);
+var IS_IOS = /iP(ad|hone|od)/.test(window?.navigator?.platform) || window?.navigator?.platform === "MacIntel" && window.navigator.maxTouchPoints > 1;
 var documentListenerAdded = false;
 var previousBodyOverflowSetting;
 var disableBodyScroll = (targetElement) => {
   if (!targetElement)
     return;
-  if (isIosDevice) {
+  if (IS_IOS) {
     document.body.style.position = "fixed";
     targetElement.ontouchmove = (event) => {
       if (event.targetTouches.length === 1) {
@@ -409,7 +409,7 @@ var disableBodyScroll = (targetElement) => {
 var enableBodyScroll = (targetElement) => {
   if (!targetElement)
     return;
-  if (isIosDevice) {
+  if (IS_IOS) {
     targetElement.ontouchstart = null;
     targetElement.ontouchmove = null;
     document.body.style.position = "";

--- a/creativecloud/scripts/utils.js
+++ b/creativecloud/scripts/utils.js
@@ -9,7 +9,6 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
-
 /*
  * ------------------------------------------------------------
  * Edit below at your own risk
@@ -50,6 +49,19 @@ const miloLibs = setLibs('/libs');
 const { createTag, localizeLink, getConfig, loadStyle, createIntersectionObserver } = await import(`${miloLibs}/utils/utils.js`);
 export { createTag, loadStyle, localizeLink, createIntersectionObserver, getConfig };
 
+function defineDeviceByScreenSize() {
+  const DESKTOP_SIZE = 1200;
+  const MOBILE_SIZE = 600;
+  const screenWidth = window.innerWidth;
+  if (screenWidth >= DESKTOP_SIZE) {
+    return 'DESKTOP';
+  }
+  if (screenWidth <= MOBILE_SIZE) {
+    return 'MOBILE';
+  }
+  return 'TABLET';
+}
+
 function getDecorateAreaFn() {
   let lcpImgSet = false;
 
@@ -86,9 +98,21 @@ function getDecorateAreaFn() {
         import(`${getConfig().codeRoot}/deps/interactive-marquee-changebg/changeBgMarquee.js`);
         break;
       }
-      case firstBlock?.classList.contains('marquee'):
-        firstBlock.querySelectorAll('img').forEach(eagerLoad);
+      case firstBlock?.classList.contains('marquee'): {
+        // Load image eagerly for specific breakpoint
+        const viewport = defineDeviceByScreenSize();
+        const bgImages = firstBlock.querySelectorAll('div').length > 1 ? firstBlock.querySelector('div') : null;
+        const lcpImgVP = {
+          MOBILE: 'div img',
+          TABLET: 'div:nth-child(2) img',
+          DESKTOP: 'div:last-child img',
+        };
+        if (bgImages?.querySelectorAll('img').length === 1) eagerLoad(bgImages?.querySelector('div img'));
+        else eagerLoad(bgImages?.querySelector(`:scope ${lcpImgVP[viewport]}`));
+        // Foreground image
+        eagerLoad(firstBlock.querySelector(':scope div:last-child > div img'));
         break;
+      }
       case firstBlock?.classList.contains('interactive-marquee'):
         firstBlock.querySelector(':scope > div:nth-child(1)').querySelectorAll('img').forEach(eagerLoad);
         fgDivs = firstBlock.querySelector(':scope > div:nth-child(2)').querySelectorAll('div:not(:first-child)');


### PR DESCRIPTION
Disabled body scroll for merch-sidenav web component used in the catalog filter (on small screens it gets opened in a modal).

The AEM PSI check fails because the merch-card JS execution time is too long (around 1,057 ms), so the TBT score is too low.
The change in the PR is related only to merch-sidenav, which is not a culprit of low TBT, thus we can merge it, and should address the TBT score of the merch-card in a separate PR.

Corresponding tacocat PR: https://git.corp.adobe.com/wcms/tacocat.js/pull/613
Corresponding mas PR: https://github.com/adobecom/mas/pull/20

Resolves: [MWPW-147716](https://jira.corp.adobe.com/browse/MWPW-147716)

Test URLs:
Before: https://main--cc--adobecom.hlx.live/products/catalog?martech=off&georouting=off&mep=off
After: https://mwpw-147716-merch-sidenav-scroll-lock--cc--adobecom.hlx.live/products/animate/free-trial-download

Here is a page for testing for QA (remove the space, I added it to make the PSI check to ignore this link): 
https://mwpw-147716-merch-sidenav-scroll-lock --cc--adobecom.hlx.live/products/catalog?martech=off&georouting=off&mep=off
