### PR TITLE
[MWPW 151457] Added stage domains map to make links environment-aware

### DIFF
--- a/creativecloud/scripts/scripts.js
+++ b/creativecloud/scripts/scripts.js
@@ -120,6 +120,15 @@ const locales = {
   cis_en: { ietf: 'en', tk: 'pps7abe.css' },
 };
 
+const stageDomainsMap = {
+  "www.adobe.com": "www.stage.adobe.com",
+  "business.adobe.com": "business.stage.adobe.com",
+  "helpx.adobe.com": "helpx.stage.adobe.com",
+  "blog.adobe.com": "blog.stage.adobe.com",
+  "developer.adobe.com": "developer-stage.adobe.com",
+  "news.adobe.com": "news.stage.adobe.com"
+};
+
 // Add any config options.
 const CONFIG = {
   contentRoot: '/cc-shared',
@@ -128,6 +137,7 @@ const CONFIG = {
   locales,
   geoRouting: 'on',
   prodDomains: ['www.adobe.com', 'helpx.adobe.com', 'business.adobe.com'],
+  stageDomainsMap,
   decorateArea,
   stage: {
     marTechUrl: 'https://assets.adobedtm.com/d4d114c60e50/a0e989131fd5/launch-2c94beadc94f-development.min.js',

--- a/creativecloud/scripts/scripts.js
+++ b/creativecloud/scripts/scripts.js
@@ -127,6 +127,7 @@ const stageDomainsMap = {
   'blog.adobe.com': 'blog.stage.adobe.com',
   'developer.adobe.com': 'developer-stage.adobe.com',
   'news.adobe.com': 'news.stage.adobe.com',
+  'firefly.adobe.com': 'firefly-stage.corp.adobe.com',
 };
 
 // Add any config options.

--- a/creativecloud/scripts/scripts.js
+++ b/creativecloud/scripts/scripts.js
@@ -121,12 +121,12 @@ const locales = {
 };
 
 const stageDomainsMap = {
-  "www.adobe.com": "www.stage.adobe.com",
-  "business.adobe.com": "business.stage.adobe.com",
-  "helpx.adobe.com": "helpx.stage.adobe.com",
-  "blog.adobe.com": "blog.stage.adobe.com",
-  "developer.adobe.com": "developer-stage.adobe.com",
-  "news.adobe.com": "news.stage.adobe.com"
+  'www.adobe.com': 'www.stage.adobe.com',
+  'business.adobe.com': 'business.stage.adobe.com',
+  'helpx.adobe.com': 'helpx.stage.adobe.com',
+  'blog.adobe.com': 'blog.stage.adobe.com',
+  'developer.adobe.com': 'developer-stage.adobe.com',
+  'news.adobe.com': 'news.stage.adobe.com'
 };
 
 // Add any config options.

--- a/creativecloud/scripts/scripts.js
+++ b/creativecloud/scripts/scripts.js
@@ -126,7 +126,7 @@ const stageDomainsMap = {
   'helpx.adobe.com': 'helpx.stage.adobe.com',
   'blog.adobe.com': 'blog.stage.adobe.com',
   'developer.adobe.com': 'developer-stage.adobe.com',
-  'news.adobe.com': 'news.stage.adobe.com'
+  'news.adobe.com': 'news.stage.adobe.com',
 };
 
 // Add any config options.


### PR DESCRIPTION
**Description**
This PR adds the `stageDomainsMap` to the config allowing links to be environment-aware.
More about this new feature can be found in [here](https://github.com/orgs/adobecom/discussions/2437).

Resolves: [MWPW-151457](https://jira.corp.adobe.com/browse/MWPW-151457)

Test URLs:
Before: https://main--cc--adobecom.hlx.page/drafts/rbogos/default?martech=off&georouting=off
After: https://main--cc--aishwaryamathuria.hlx.page/drafts/rbogos/default?martech=off&georouting=off&milolibs=mwpw-146056-stage-links--milo--robert-bogos
