### PR TITLE
MWPW-147504 | Thumbnail images in selector tray getting cropped in mobile mode

### DIFF
--- a/creativecloud/features/interactive-components/selector-tray/selector-tray.css
+++ b/creativecloud/features/interactive-components/selector-tray/selector-tray.css
@@ -50,6 +50,7 @@
   background-position: center;
   outline: none;
   position: relative;
+  max-width: 30%;
 }
 
 .interactive-enabled .step-selector-tray .selector-tray .tray-items a.tray-thumbnail .tray-thumbnail-img {
@@ -106,9 +107,20 @@
     flex-direction: column;
   }
 
+  .interactive-enabled .step-selector-tray .selector-tray .tray-items a.tray-thumbnail {
+    max-width: 80px;
+    min-height: 80px;
+    height: auto;
+    overflow: hidden;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+
   .interactive-enabled .step-selector-tray .selector-tray .tray-items a.tray-thumbnail .tray-thumbnail-img {
     width: auto;
-    min-width: 80px;
+    min-width: auto;
+    max-width: unset;
     height: 120px;
     min-height: 120px;
     max-height: 120px;

--- a/creativecloud/features/interactive-components/selector-tray/selector-tray.css
+++ b/creativecloud/features/interactive-components/selector-tray/selector-tray.css
@@ -41,31 +41,36 @@
   justify-content: space-between;
 }
 
-.interactive-enabled .step-selector-tray .selector-tray .tray-items a.tray-thumbnail-img {
+.interactive-enabled .step-selector-tray .selector-tray .tray-items a.tray-thumbnail {
   display: block;
-  width: 30%;
-  height: 80px;
+  width: auto;
+  height: auto;
   background-repeat: no-repeat;
   background-size: cover;
   background-position: center;
   outline: none;
+  position: relative;
 }
 
-.interactive-enabled .step-selector-tray .selector-tray .tray-items a.tray-thumbnail-img .preload-img {
-  display: none;
+.interactive-enabled .step-selector-tray .selector-tray .tray-items a.tray-thumbnail .tray-thumbnail-img {
+  height: 80px;
+  width: auto;
 }
 
-.interactive-enabled .step-selector-tray .selector-tray .tray-items a.tray-thumbnail-img .tray-thumbnail-outline {
+.interactive-enabled .step-selector-tray .selector-tray .tray-items a.tray-thumbnail .tray-thumbnail-outline {
   display: none;
   box-sizing: content-box;
   height: calc(100% - 10px);
   width: calc(100% - 10px);
   border: 5px solid var(--prompt-highlight-color);
+  position: absolute;
+  top: 0;
+  left: 0;
 }
 
-.interactive-enabled .step-selector-tray .selector-tray .tray-items a.tray-thumbnail-img.thumbnail-selected .tray-thumbnail-outline,
-.interactive-enabled .step-selector-tray .selector-tray .tray-items a.tray-thumbnail-img:focus-visible .tray-thumbnail-outline,
-.interactive-enabled .step-selector-tray .selector-tray .tray-items a.tray-thumbnail-img:hover .tray-thumbnail-outline {
+.interactive-enabled .step-selector-tray .selector-tray .tray-items a.tray-thumbnail.thumbnail-selected .tray-thumbnail-outline,
+.interactive-enabled .step-selector-tray .selector-tray .tray-items a.tray-thumbnail:focus-visible .tray-thumbnail-outline,
+.interactive-enabled .step-selector-tray .selector-tray .tray-items a.tray-thumbnail:hover .tray-thumbnail-outline {
   display: block;
 }
 
@@ -101,12 +106,15 @@
     flex-direction: column;
   }
 
-  .interactive-enabled .step-selector-tray .selector-tray .tray-items a.tray-thumbnail-img {
-    width: 80px;
+  .interactive-enabled .step-selector-tray .selector-tray .tray-items a.tray-thumbnail .tray-thumbnail-img {
+    width: auto;
+    min-width: 80px;
     height: 120px;
+    min-height: 120px;
+    max-height: 120px;
   }
 
-  .interactive-enabled .step-selector-tray .selector-tray .tray-items a.tray-thumbnail-img .tray-thumbnail-outline {
+  .interactive-enabled .step-selector-tray .selector-tray .tray-items a.tray-thumbnail .tray-thumbnail-outline {
     height: calc(100% - 12px);
     width: calc(100% - 12px);
     border: 6px solid var(--prompt-highlight-color);

--- a/creativecloud/features/interactive-components/selector-tray/selector-tray.js
+++ b/creativecloud/features/interactive-components/selector-tray/selector-tray.js
@@ -19,14 +19,14 @@ function getStartingPathIdx(data) {
 
 function createSelectorThumbnail(pic, pathId, displayImg) {
   const src = getImgSrc(pic);
+  const { alt } = pic.querySelector('img');
   const outline = createTag('div', { class: 'tray-thumbnail-outline' });
-  const a = createTag('a', { class: 'tray-thumbnail-img', href: '#' }, outline);
-  a.style.backgroundImage = `url(${src})`;
+  const a = createTag('a', { class: 'tray-thumbnail', href: '#' });
   [a.dataset.dispSrc, a.dataset.dispAlt] = displayImg;
   a.dataset.dispPth = pathId;
-  const img = createTag('img', { class: 'preload-img', src });
+  const img = createTag('img', { class: 'tray-thumbnail-img', src, alt });
   const analyticsHolder = createTag('div', { class: 'interactive-link-analytics-text' }, pic.querySelector('img').alt);
-  a.append(img, analyticsHolder);
+  a.append(img, outline, analyticsHolder);
   if (pathId === 0) a.classList.add('thumbnail-selected');
   return a;
 }

--- a/test/features/interactive-components/selector-tray/selector-tray.test.js
+++ b/test/features/interactive-components/selector-tray/selector-tray.test.js
@@ -20,11 +20,11 @@ describe('Selector tray', () => {
   });
   it('should remove selection on hover', async () => {
     expect(document.querySelector('.step-selector-tray .thumbnail-selected')).to.exist;
-    document.querySelector('.tray-thumbnail-img').dispatchEvent(new Event('mouseover'));
+    document.querySelector('.tray-thumbnail').dispatchEvent(new Event('mouseover'));
     expect(document.querySelector('.step-selector-tray .thumbnail-selected')).to.not.exist;
   });
   it('should have next layer on selection', async () => {
-    document.querySelector('.tray-thumbnail-img').dispatchEvent(new Event('click'));
+    document.querySelector('.tray-thumbnail').dispatchEvent(new Event('click'));
     await new Promise((res) => { setTimeout(() => { res(); }, 200); });
     expect(document.querySelector('.interactive-holder.step-crop')).to.exist;
   });
@@ -34,7 +34,7 @@ describe('Selector tray', () => {
     expect(document.querySelector('.step-selector-tray .thumbnail-selected')).to.exist;
   });
   it('should have not have thumbnail on selection', async () => {
-    const thumbnail = document.querySelector('.show-layer .tray-thumbnail-img.thumbnail-selected');
+    const thumbnail = document.querySelector('.show-layer .tray-thumbnail.thumbnail-selected');
     thumbnail.dispatchEvent(new Event('touchstart'));
     await new Promise((res) => { setTimeout(() => { res(); }, 200); });
   });


### PR DESCRIPTION
Changing the image width to remain auto in place of adjusting to 30% of the tray in mobile.
The space would increase as screen resizes.

Resolves: [MWPW-147504](https://jira.corp.adobe.com/browse/MWPW-147504)

**Test URLs:**
- Before: https://main--cc--adobecom.hlx.live/products/photoshop/explore?martech=off&mep=off&georouting=off
- After: https://MWPW-147504--cc--adobecom.hlx.live/products/photoshop/explore?martech=off&mep=off&georouting=off
