### PR TITLE
MWPW-153428-Eager load marquee background image only for current breakpoint

### DIFF
--- a/creativecloud/scripts/utils.js
+++ b/creativecloud/scripts/utils.js
@@ -106,8 +106,10 @@ function getDecorateAreaFn() {
           TABLET: 'div:nth-child(2) img',
           DESKTOP: 'div:nth-child(3) img',
         };
-        eagerLoad(firstBlock.querySelector(lcpImageByViewport[viewport]));
-        // Last image of last column of last row
+        const backgroundImages = firstBlock.querySelector('div:nth-child(1)');
+        if (backgroundImages.querySelectorAll('img').length === 1) eagerLoad(firstBlock.querySelector('div:first-child img'));
+        else eagerLoad(firstBlock.querySelector(lcpImageByViewport[viewport]));
+        // Foreground image
         eagerLoad(firstBlock.querySelector('div:nth-child(2) > div img'));
         break;
       }

--- a/creativecloud/scripts/utils.js
+++ b/creativecloud/scripts/utils.js
@@ -9,7 +9,7 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
-
+import defineDeviceByScreenSize from './decorate.js';
 /*
  * ------------------------------------------------------------
  * Edit below at your own risk
@@ -87,11 +87,12 @@ function getDecorateAreaFn() {
         break;
       }
       case firstBlock?.classList.contains('marquee'):
-        // First image of first row
-        eagerLoad(firstBlock.querySelector('div:first-child img'));
+        // Load image eagerly for specific breakpoint
+        if (defineDeviceByScreenSize() === 'MOBILE') eagerLoad(firstBlock.querySelector('div:first-child img'));
+        else if (defineDeviceByScreenSize() === 'TABLET') eagerLoad(firstBlock.querySelector('div:second-child img'));
+        else if (defineDeviceByScreenSize() === 'DESKTOP') eagerLoad(firstBlock.querySelector('div:third-child img'));
         // Last image of last column of last row
         eagerLoad(firstBlock.querySelector('div:last-child > div:last-child img'));
-        //firstBlock.querySelectorAll('img').forEach(eagerLoad);
         break;
       case firstBlock?.classList.contains('interactive-marquee'):
         firstBlock.querySelector(':scope > div:nth-child(1)').querySelectorAll('img').forEach(eagerLoad);

--- a/creativecloud/scripts/utils.js
+++ b/creativecloud/scripts/utils.js
@@ -102,10 +102,10 @@ function getDecorateAreaFn() {
         // Load image eagerly for specific breakpoint
         const viewport = defineDeviceByScreenSize();
         const lcpImageByViewport = {
-          'MOBILE': 'div:first-child img',
-          'TABLET': 'div:nth-child(2) img',
-          'DESKTOP': 'div:nth-child(3) img',
-        }    
+          MOBILE: 'div:first-child img',
+          TABLET: 'div:nth-child(2) img',
+          DESKTOP: 'div:nth-child(3) img',
+        };
         eagerLoad(firstBlock.querySelector(lcpImageByViewport[viewport]));
         // Last image of last column of last row
         eagerLoad(firstBlock.querySelector('div:last-child > div:last-child img'));

--- a/creativecloud/scripts/utils.js
+++ b/creativecloud/scripts/utils.js
@@ -101,16 +101,16 @@ function getDecorateAreaFn() {
       case firstBlock?.classList.contains('marquee'): {
         // Load image eagerly for specific breakpoint
         const viewport = defineDeviceByScreenSize();
-        const lcpImageByViewport = {
+        const bgImages = firstBlock.querySelectorAll('div').length > 1 ? firstBlock.querySelector('div') : null;
+        const lcpImgVP = {
           MOBILE: 'div img',
           TABLET: 'div:nth-child(2) img',
-          DESKTOP: 'div:nth-child(3) img',
+          DESKTOP: 'div:last-child img',
         };
-        const backgroundImages = firstBlock.querySelector('div');
-        if (backgroundImages.querySelectorAll('img').length === 1) eagerLoad(firstBlock.querySelector('div img'));
-        else eagerLoad(firstBlock.querySelector(lcpImageByViewport[viewport]));
+        if (bgImages?.querySelectorAll('img').length === 1) eagerLoad(bgImages?.querySelector('div img'));
+        else eagerLoad(bgImages?.querySelector(`:scope ${lcpImgVP[viewport]}`));
         // Foreground image
-        eagerLoad(firstBlock.querySelector('div:nth-child(2) > div img'));
+        eagerLoad(firstBlock.querySelector(':scope div:last-child > div img'));
         break;
       }
       case firstBlock?.classList.contains('interactive-marquee'):

--- a/creativecloud/scripts/utils.js
+++ b/creativecloud/scripts/utils.js
@@ -95,7 +95,7 @@ function getDecorateAreaFn() {
         // Last image of last column of last row
         eagerLoad(firstBlock.querySelector('div:last-child > div:last-child img'));
         break;
-      }  
+      }
       case firstBlock?.classList.contains('interactive-marquee'):
         firstBlock.querySelector(':scope > div:nth-child(1)').querySelectorAll('img').forEach(eagerLoad);
         fgDivs = firstBlock.querySelector(':scope > div:nth-child(2)').querySelectorAll('div:not(:first-child)');

--- a/creativecloud/scripts/utils.js
+++ b/creativecloud/scripts/utils.js
@@ -90,7 +90,7 @@ function getDecorateAreaFn() {
         // Load image eagerly for specific breakpoint
         if (defineDeviceByScreenSize() === 'MOBILE') eagerLoad(firstBlock.querySelector('div:first-child img'));
         else if (defineDeviceByScreenSize() === 'TABLET') eagerLoad(firstBlock.querySelector('div:second-child img'));
-        else if (defineDeviceByScreenSize() === 'DESKTOP') eagerLoad(firstBlock.querySelector('div:third-child img'));
+        else if (defineDeviceByScreenSize() === 'DESKTOP') eagerLoad(firstBlock.querySelector('div:last-child img'));
         // Last image of last column of last row
         eagerLoad(firstBlock.querySelector('div:last-child > div:last-child img'));
         break;

--- a/creativecloud/scripts/utils.js
+++ b/creativecloud/scripts/utils.js
@@ -9,7 +9,6 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
-import defineDeviceByScreenSize from './decorate.js';
 /*
  * ------------------------------------------------------------
  * Edit below at your own risk
@@ -50,6 +49,19 @@ const miloLibs = setLibs('/libs');
 const { createTag, localizeLink, getConfig, loadStyle, createIntersectionObserver } = await import(`${miloLibs}/utils/utils.js`);
 export { createTag, loadStyle, localizeLink, createIntersectionObserver, getConfig };
 
+function defineDeviceByScreenSize() {
+  const DESKTOP_SIZE = 1200;
+  const MOBILE_SIZE = 600;
+  const screenWidth = window.innerWidth;
+  if (screenWidth >= DESKTOP_SIZE) {
+    return 'DESKTOP';
+  }
+  if (screenWidth <= MOBILE_SIZE) {
+    return 'MOBILE';
+  }
+  return 'TABLET';
+}
+
 function getDecorateAreaFn() {
   let lcpImgSet = false;
 
@@ -89,9 +101,12 @@ function getDecorateAreaFn() {
       case firstBlock?.classList.contains('marquee'): {
         // Load image eagerly for specific breakpoint
         const viewport = defineDeviceByScreenSize();
-        if (viewport === 'MOBILE') eagerLoad(firstBlock.querySelector('div:first-child img'));
-        else if (viewport === 'TABLET') eagerLoad(firstBlock.querySelector('div:nth-child(2) img'));
-        else if (viewport === 'DESKTOP') eagerLoad(firstBlock.querySelector('div:last-child img'));
+        const lcpImageByViewport = {
+          'MOBILE': 'div:first-child img',
+          'TABLET': 'div:nth-child(2) img',
+          'DESKTOP': 'div:nth-child(3) img',
+        }    
+        eagerLoad(firstBlock.querySelector(lcpImageByViewport[viewport]));
         // Last image of last column of last row
         eagerLoad(firstBlock.querySelector('div:last-child > div:last-child img'));
         break;

--- a/creativecloud/scripts/utils.js
+++ b/creativecloud/scripts/utils.js
@@ -89,7 +89,7 @@ function getDecorateAreaFn() {
       case firstBlock?.classList.contains('marquee'):
         // Load image eagerly for specific breakpoint
         if (defineDeviceByScreenSize() === 'MOBILE') eagerLoad(firstBlock.querySelector('div:first-child img'));
-        else if (defineDeviceByScreenSize() === 'TABLET') eagerLoad(firstBlock.querySelector('div:second-child img'));
+        else if (defineDeviceByScreenSize() === 'TABLET') eagerLoad(firstBlock.querySelector('div:nth-child(2) img'));
         else if (defineDeviceByScreenSize() === 'DESKTOP') eagerLoad(firstBlock.querySelector('div:last-child img'));
         // Last image of last column of last row
         eagerLoad(firstBlock.querySelector('div:last-child > div:last-child img'));

--- a/creativecloud/scripts/utils.js
+++ b/creativecloud/scripts/utils.js
@@ -107,7 +107,7 @@ function getDecorateAreaFn() {
           DESKTOP: 'div:nth-child(3) img',
         };
         const backgroundImages = firstBlock.querySelector('div');
-        if (backgroundImages.querySelectorAll('img').length === 1) eagerLoad(firstBlock.querySelector('div:first-child img'));
+        if (backgroundImages.querySelectorAll('img').length === 1) eagerLoad(firstBlock.querySelector('div img'));
         else eagerLoad(firstBlock.querySelector(lcpImageByViewport[viewport]));
         // Foreground image
         eagerLoad(firstBlock.querySelector('div:nth-child(2) > div img'));

--- a/creativecloud/scripts/utils.js
+++ b/creativecloud/scripts/utils.js
@@ -108,7 +108,7 @@ function getDecorateAreaFn() {
         };
         eagerLoad(firstBlock.querySelector(lcpImageByViewport[viewport]));
         // Last image of last column of last row
-        eagerLoad(firstBlock.querySelector('div:last-child > div:last-child img'));
+        eagerLoad(firstBlock.querySelector('div:nth-child(2) > div img'));
         break;
       }
       case firstBlock?.classList.contains('interactive-marquee'):

--- a/creativecloud/scripts/utils.js
+++ b/creativecloud/scripts/utils.js
@@ -87,7 +87,11 @@ function getDecorateAreaFn() {
         break;
       }
       case firstBlock?.classList.contains('marquee'):
-        firstBlock.querySelectorAll('img').forEach(eagerLoad);
+        // First image of first row
+        eagerLoad(firstBlock.querySelector('div:first-child img'));
+        // Last image of last column of last row
+        eagerLoad(firstBlock.querySelector('div:last-child > div:last-child img'));
+        //firstBlock.querySelectorAll('img').forEach(eagerLoad);
         break;
       case firstBlock?.classList.contains('interactive-marquee'):
         firstBlock.querySelector(':scope > div:nth-child(1)').querySelectorAll('img').forEach(eagerLoad);

--- a/creativecloud/scripts/utils.js
+++ b/creativecloud/scripts/utils.js
@@ -102,11 +102,11 @@ function getDecorateAreaFn() {
         // Load image eagerly for specific breakpoint
         const viewport = defineDeviceByScreenSize();
         const lcpImageByViewport = {
-          MOBILE: 'div:first-child img',
+          MOBILE: 'div img',
           TABLET: 'div:nth-child(2) img',
           DESKTOP: 'div:nth-child(3) img',
         };
-        const backgroundImages = firstBlock.querySelector('div:nth-child(1)');
+        const backgroundImages = firstBlock.querySelector('div');
         if (backgroundImages.querySelectorAll('img').length === 1) eagerLoad(firstBlock.querySelector('div:first-child img'));
         else eagerLoad(firstBlock.querySelector(lcpImageByViewport[viewport]));
         // Foreground image

--- a/creativecloud/scripts/utils.js
+++ b/creativecloud/scripts/utils.js
@@ -86,7 +86,7 @@ function getDecorateAreaFn() {
         import(`${getConfig().codeRoot}/deps/interactive-marquee-changebg/changeBgMarquee.js`);
         break;
       }
-      case firstBlock?.classList.contains('marquee'):
+      case firstBlock?.classList.contains('marquee'): {
         // Load image eagerly for specific breakpoint
         const viewport = defineDeviceByScreenSize();
         if (viewport === 'MOBILE') eagerLoad(firstBlock.querySelector('div:first-child img'));
@@ -95,6 +95,7 @@ function getDecorateAreaFn() {
         // Last image of last column of last row
         eagerLoad(firstBlock.querySelector('div:last-child > div:last-child img'));
         break;
+      }  
       case firstBlock?.classList.contains('interactive-marquee'):
         firstBlock.querySelector(':scope > div:nth-child(1)').querySelectorAll('img').forEach(eagerLoad);
         fgDivs = firstBlock.querySelector(':scope > div:nth-child(2)').querySelectorAll('div:not(:first-child)');

--- a/creativecloud/scripts/utils.js
+++ b/creativecloud/scripts/utils.js
@@ -88,9 +88,10 @@ function getDecorateAreaFn() {
       }
       case firstBlock?.classList.contains('marquee'):
         // Load image eagerly for specific breakpoint
-        if (defineDeviceByScreenSize() === 'MOBILE') eagerLoad(firstBlock.querySelector('div:first-child img'));
-        else if (defineDeviceByScreenSize() === 'TABLET') eagerLoad(firstBlock.querySelector('div:nth-child(2) img'));
-        else if (defineDeviceByScreenSize() === 'DESKTOP') eagerLoad(firstBlock.querySelector('div:last-child img'));
+        const viewport = defineDeviceByScreenSize();
+        if (viewport === 'MOBILE') eagerLoad(firstBlock.querySelector('div:first-child img'));
+        else if (viewport === 'TABLET') eagerLoad(firstBlock.querySelector('div:nth-child(2) img'));
+        else if (viewport === 'DESKTOP') eagerLoad(firstBlock.querySelector('div:last-child img'));
         // Last image of last column of last row
         eagerLoad(firstBlock.querySelector('div:last-child > div:last-child img'));
         break;


### PR DESCRIPTION
* Eager load marquee background image only for current breakpoint

Resolves: [MWPW-153428](https://jira.corp.adobe.com/browse/MWPW-153428)

**Test URLs:**
- Before: https://stage--cc--adobecom.hlx.live/drafts/ruchika/eager-load?martech=off
- After: https://eagerload--cc--adobecom.hlx.live/drafts/ruchika/eager-load?martech=off

Test Page with 2 background images:

https://eagerload--cc--adobecom.hlx.live/drafts/ruchika/eager-load2?martech=off

Test Page with 1 background image:

https://eagerload--cc--adobecom.hlx.live/drafts/ruchika/eager-load1?martech=off

Test Page with no background image:

https://eagerload--cc--adobecom.hlx.live/drafts/ruchika/eager-load3?martech=off