### PR TITLE
MWPW-147481 | Enable configurable prompt for generate after select step

### DIFF
--- a/creativecloud/features/interactive-components/generate/generate.js
+++ b/creativecloud/features/interactive-components/generate/generate.js
@@ -1,11 +1,21 @@
 import { createTag } from '../../../scripts/utils.js';
 
+function getGenerateConfig(data) {
+  const genCfg = data.stepConfigs[data.stepIndex].querySelector('ul, ol');
+  const lastp = data.stepConfigs[data.stepIndex].querySelector(':scope > div > p:last-child');
+  if (!genCfg) return lastp;
+  const dpth = data.displayPath;
+  const allCfgs = genCfg.querySelectorAll('li');
+  const selectCfg = (dpth >= 0 && allCfgs.length > dpth) ? allCfgs[dpth] : allCfgs[0];
+  return selectCfg;
+}
+
 export default async function stepInit(data) {
   data.target.classList.add('step-generate');
   const config = data.stepConfigs[data.stepIndex];
   const layer = createTag('div', { class: `layer layer-${data.stepIndex}` });
-  const lastp = config.querySelector(':scope > div > p:last-child');
-  const [searchText, btnText] = lastp.textContent.trim().split('|');
+  const gerenateCfg = getGenerateConfig(data);
+  const [searchText, btnText] = gerenateCfg.textContent.trim().split('|');
   const genfillDiv = createTag('div', { class: 'generate-prompt-button body-m' });
   const searchBar = createTag('div', { class: 'generate-text' }, `${searchText}`);
   const searchBarContainer = createTag('div', { class: 'generate-text-container' }, searchBar);


### PR DESCRIPTION
Adding an option to configure a generate button with prompt that is configurable based on the selected option in the selector tray.
/drafts/mathuria/interactiveelems/demo/handoff/totebag/brightorb

Resolves: [MWPW-147481](https://jira.corp.adobe.com/browse/MWPW-147481)

**Test URLs:**
- Before: https://main--cc--adobecom.hlx.live/drafts/mathuria/interactiveelems/demo/handoff/totebag/totebag-selector-update?martech=off
- After: https://mwpw-147481--cc--adobecom.hlx.live/drafts/mathuria/interactiveelems/demo/handoff/totebag/totebag-selector-update?martech=off
