### PR TITLE
[MWPW-154272]: Eager Loading only one image for each viewport

### DIFF
--- a/creativecloud/scripts/utils.js
+++ b/creativecloud/scripts/utils.js
@@ -102,7 +102,7 @@ function getDecorateAreaFn() {
         const viewport = defineDeviceByScreenSize();
         const bgImages = firstBlock.querySelectorAll('div').length > 1 ? firstBlock.querySelector('div') : null;
         const lcpImgVP = {
-          MOBILE: 'div img',
+          MOBILE: 'div:first-child img',
           TABLET: 'div:nth-child(2) img',
           DESKTOP: 'div:last-child img',
         };

--- a/creativecloud/scripts/utils.js
+++ b/creativecloud/scripts/utils.js
@@ -106,7 +106,7 @@ function getDecorateAreaFn() {
           TABLET: 'div:nth-child(2) img',
           DESKTOP: 'div:last-child img',
         };
-        if (bgImages?.querySelectorAll('img').length === 1 && bgImages.querySelectorAll('div').length === 1 ) eagerLoad(bgImages?.querySelector('div img'));
+        if (bgImages?.querySelectorAll('img').length === 1 && bgImages.querySelectorAll('div').length === 1) eagerLoad(bgImages?.querySelector('div img'));
         else eagerLoad(bgImages?.querySelector(`:scope ${lcpImgVP[viewport]}`));
         // Foreground image
         eagerLoad(firstBlock.querySelector(':scope div:last-child > div img'));

--- a/creativecloud/scripts/utils.js
+++ b/creativecloud/scripts/utils.js
@@ -106,7 +106,7 @@ function getDecorateAreaFn() {
           TABLET: 'div:nth-child(2) img',
           DESKTOP: 'div:last-child img',
         };
-        if (bgImages?.querySelectorAll('img').length === 1) eagerLoad(bgImages?.querySelector('div img'));
+        if (bgImages?.querySelectorAll('img').length === 1 && bgImages.querySelectorAll('div').length === 1 ) eagerLoad(bgImages?.querySelector('div img'));
         else eagerLoad(bgImages?.querySelector(`:scope ${lcpImgVP[viewport]}`));
         // Foreground image
         eagerLoad(firstBlock.querySelector(':scope div:last-child > div img'));


### PR DESCRIPTION
when there is only 1 image authored in tablet and in desktop we are able to see the eagerload is seen rendered for when the page is not in that viewport

Resolves: [[MWPW-154272]](https://jira.corp.adobe.com/browse/MWPW-NUMBER)

**Test URLs:**
- Before: https://main--cc--adobecom.hlx.live/drafts/Souj/html/marquee-variant61#
- After: https://loadsingleimg--cc--adobecom.hlx.live/drafts/Souj/html/marquee-variant61#
