### PR TITLE
OPT-27991 AEXG4866 - AX take over of FF T2i SEO page - FIXES

### DIFF
--- a/creativecloud/scripts/mep/aexg4866/firefly/firefly-masonry.js
+++ b/creativecloud/scripts/mep/aexg4866/firefly/firefly-masonry.js
@@ -44,6 +44,8 @@ function getImgSrc(pic, viewport = '') {
 async function createEmbellishment(allP, media, mediaMobile, ic, mode, interactiveMode, el) {
   const [promptText, buttonText] = allP[3].innerText.split('|');
   const fireflyPrompt = await createPromptField(`${promptText}`, `${buttonText}`, `ff-masonry, ${interactiveMode}`);
+  const promptCharLimit = '1024';
+  fireflyPrompt.querySelector('input').setAttribute('maxlength', promptCharLimit);
   fireflyPrompt.classList.add('ff-masonry-prompt');
   const enticementText = allP[0].textContent.trim();
   const enticementIcon = allP[0].querySelector('a').href;
@@ -62,9 +64,8 @@ async function createEmbellishment(allP, media, mediaMobile, ic, mode, interacti
         window.location.href = allP[3].querySelector('a').href;
       } else if (el.classList.contains('express')) {
         const config = getConfig();
-        const promptCharLimit = 1024;
         const axEnvUrl = config.env?.name?.includes('prod') ? 'https://adobesparkpost-web.app.link/e/RohcL3leMKb' : 'https://adobesparkpost.test-app.link/e/R1fMMbgHLKb';
-        window.location.href = `${axEnvUrl}?prompt=${userprompt.length <= promptCharLimit ? userprompt : userprompt.substring(0, promptCharLimit)}`;
+        window.location.href = `${axEnvUrl}?prompt=${userprompt}`;
       }
     });
     focusOnInput(null, createTag, promptInput);


### PR DESCRIPTION
* Test Version of firefly-masonry block. Simple fix to increase charlimit on marquee prompt input via html attributes instead of manual javascript logic check before redirecting to AX web app on cta click. 

Resolves: [OPT-27991](https://jira.corp.adobe.com/browse/OPT-27991)

**Test URLs:**
- Before: https://stage--cc--adobecom.hlx.live/products/firefly/features/text-to-image?mep=%2Fcc-shared%2Ffragments%2Ftests%2F2024%2Fq3%2Faexg4866%2Faexg4866.json--target-var1-newmarquee&target=off
- After: https://aexg4866fixes--cc--adobecom.hlx.live/products/firefly/features/text-to-image?mep=%2Fcc-shared%2Ffragments%2Ftests%2F2024%2Fq3%2Faexg4866%2Faexg4866.json--target-var1-newmarquee&target=off
