### PR TITLE
[MWPW 151457] Added stage domains map to make links environment-aware

### DIFF
--- a/creativecloud/scripts/scripts.js
+++ b/creativecloud/scripts/scripts.js
@@ -123,6 +123,16 @@ const locales = {
   cis_en: { ietf: 'en', tk: 'pps7abe.css' },
 };
 
+const stageDomainsMap = {
+  'www.adobe.com': 'www.stage.adobe.com',
+  'business.adobe.com': 'business.stage.adobe.com',
+  'helpx.adobe.com': 'helpx.stage.adobe.com',
+  'blog.adobe.com': 'blog.stage.adobe.com',
+  'developer.adobe.com': 'developer-stage.adobe.com',
+  'news.adobe.com': 'news.stage.adobe.com',
+  'firefly.adobe.com': 'firefly-stage.corp.adobe.com',
+};
+
 // Add any config options.
 const CONFIG = {
   contentRoot: '/cc-shared',
@@ -131,6 +141,7 @@ const CONFIG = {
   locales,
   geoRouting: 'on',
   prodDomains: ['www.adobe.com', 'helpx.adobe.com', 'business.adobe.com'],
+  stageDomainsMap,
   decorateArea,
   stage: {
     pdfViewerClientId: '9f7f19a46bd542e2b8548411e51eb4d4',


### PR DESCRIPTION
* This PR adds the `stageDomainsMap` to the config allowing links to be environment-aware.
More about this new feature can be found in [here](https://github.com/orgs/adobecom/discussions/2437).

* This PR is copy of https://github.com/adobecom/cc/pull/336 Test urls were not accessible on the previous hence a new PR has been opened.

Resolves: [MWPW-151457](https://jira.corp.adobe.com/browse/MWPW-151457)

**Test URLs:**
- Before: https://stage--cc--adobecom.hlx.live/drafts/rbogos/default?martech=off
- After: https://mwpw-151457--cc--adobecom.hlx.live/drafts/rbogos/default?martech=off
