### PR TITLE
MWPW-153405 | Changing the selector tray thumbnail size

### DIFF
--- a/creativecloud/features/interactive-components/selector-tray/selector-tray.css
+++ b/creativecloud/features/interactive-components/selector-tray/selector-tray.css
@@ -88,7 +88,7 @@
   }
 
   .interactive-enabled .step-selector-tray .selector-tray .tray-items {
-    gap: 16px
+    gap: 14px
   }
 
   .interactive-enabled .step-selector-tray .selector-tray .tray-title {
@@ -102,14 +102,16 @@
   }
 
   .interactive-enabled .step-selector-tray .selector-tray .tray-items a.tray-thumbnail-img {
-    width: 80px;
-    height: 120px;
+    width: 98px;
+    height: 98px;
+    border-radius: 4px;
   }
 
   .interactive-enabled .step-selector-tray .selector-tray .tray-items a.tray-thumbnail-img .tray-thumbnail-outline {
-    height: calc(100% - 12px);
-    width: calc(100% - 12px);
-    border: 6px solid var(--prompt-highlight-color);
+    height: calc(100% - 6px);
+    width: calc(100% - 6px);
+    border: 3px solid var(--prompt-highlight-color);
+    border-radius: 4px;
   }
 }
 


### PR DESCRIPTION
* Changing the selector tray thumbnail size to be 98px x 98px as per the figma. 
* Reducing the border width to be 3px as per the figma

Resolves: [MWPW-153405](https://jira.corp.adobe.com/browse/MWPW-153405)

**Test URLs:**
- Before: https://main--cc--adobecom.hlx.live/products/photoshop/explore?martech=off&georouting=off&mep=off
- After: https://mwpw-153411--cc--adobecom.hlx.live/products/photoshop/explore?martech=off&georouting=off&mep=off
