### PR TITLE
fix(MWPW-154091):ready for stage label is mandatory.

### DIFF
--- a/.github/workflows/merge-to-stage.js
+++ b/.github/workflows/merge-to-stage.js
@@ -190,7 +190,7 @@ const getPRs = async () => {
       );
       return false;
     }
-    if (!labels.includes(LABELS.verified)) {
+    if (!labels.includes(LABELS.verified) || !labels.includes(LABELS.readyForStage)) {
       commentOnPR(
         `Skipped merging ${number}: ${title} due to missing verified label. kindly make sure that the PR has been verified`,
         number

--- a/.github/workflows/merge-to-stage.js
+++ b/.github/workflows/merge-to-stage.js
@@ -11,7 +11,7 @@ let body = `
 const REQUIRED_APPROVALS = process.env.REQUIRED_APPROVALS || 2;
 const LABELS = {
   highPriority: 'high priority',
-  readyForStage: 'Ready for Stage',
+  readyForStage: 'ready for stage',
   SOTPrefix: 'SOT',
   zeroImpact: 'zero-impact',
   verified: 'verified',


### PR DESCRIPTION
* The "ready for stage" label is mandatory before merging Pull requests into stage branch.
Resolves: [MWPW-154091](https://jira.corp.adobe.com/browse/MWPW-154091)

Test URLs:

Before: https://main--cc--adobecom.hlx.live/?martech=off
After: https://mwpw-154091--cc--sharath-kannan.hlx.live/?martech=off