### PR TITLE
MWPW-155431 - Don't convert adobe.com urls to stage.adobe.com url

### DIFF
--- a/creativecloud/scripts/scripts.js
+++ b/creativecloud/scripts/scripts.js
@@ -124,7 +124,6 @@ const locales = {
 };
 
 const stageDomainsMap = {
-  'www.adobe.com': 'www.stage.adobe.com',
   'business.adobe.com': 'business.stage.adobe.com',
   'helpx.adobe.com': 'helpx.stage.adobe.com',
   'blog.adobe.com': 'blog.stage.adobe.com',


### PR DESCRIPTION
* Don't convert adobe.com urls to stage.adobe.com url

Resolves: [MWPW-155431](https://jira.corp.adobe.com/browse/MWPW-155431)

**Test URLs:**
- Before: https://stage--cc--adobecom.hlx.live/drafts/rbogos/default?martech=off
- After: https://stagedomain--cc--adobecom.hlx.live/drafts/rbogos/default?martech=off
