### PR TITLE
MWPW-155686 Catalog Milo: Preview Index Follow Up

### DIFF
--- a/.github/preview-index/package.json
+++ b/.github/preview-index/package.json
@@ -5,7 +5,8 @@
   "type": "commonjs",
   "sideEffects": false,
   "scripts": {
-    "index": "node src/update.js"
+    "index": "node src/update.js",
+    "testevent": "node src/testevent.js"
   },
   "dependencies": {
     "@azure/msal-node": "^2.11.0",

--- a/.github/preview-index/src/testevent.js
+++ b/.github/preview-index/src/testevent.js
@@ -1,0 +1,2 @@
+console.log('PREVIEW EVENT');
+console.log(process.env.npm_config_payload);

--- a/.github/workflows/run-preview-index-test.yaml
+++ b/.github/workflows/run-preview-index-test.yaml
@@ -21,6 +21,19 @@ jobs:
         node-version: [18.x]
 
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Install dependencies
+        run: |
+          cd .github/preview-index
+          npm install
+
       - name: Test reindex preview resources
         run: |
           cd .github/preview-index

--- a/.github/workflows/run-preview-index-test.yaml
+++ b/.github/workflows/run-preview-index-test.yaml
@@ -1,0 +1,27 @@
+name: Run preview index test
+
+on:
+  workflow_dispatch: # Allow manual trigger
+  repository_dispatch:
+    types:
+      - resource-previewed
+
+jobs:
+  print:
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          echo "Status: ${{ github.event.client_payload.status }}"
+          echo "Path: ${{ github.event.client_payload.path }}"
+  run-preview-index-test:
+    name: Test reindexing preview resources
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [18.x]
+
+    steps:
+      - name: Test reindex preview resources
+        run: |
+          cd .github/preview-index
+          npm run testevent --payload=${{ toJson(github.event.client_payload) }}


### PR DESCRIPTION
GitHub officially supports the event `resource-published` in GitHub actions. Unofficially it also supports `resource-previewed` but we need to make sure this is true. It is not enabled for forks so this PR has to be merged to do this test.
If this event works we will be able to properly index previewed resources instead of current "index all" process that runs on every 2 hours.

Resolves: [MWPW-155686](https://jira.corp.adobe.com/browse/MWPW-155686)

**Test URLs:**
- Before: https://main--cc--adobecom.hlx.live/?martech=off
- After: https://mwpw155686preview--cc--bozojovicic.hlx.live/?martech=off
