### PR TITLE
[MWPW-156972] Generate button is seen moved out of the screen in ipad landscape mode for RTL Locale

### DIFF
--- a/creativecloud/features/interactive-components/generate/generate.css
+++ b/creativecloud/features/interactive-components/generate/generate.css
@@ -140,7 +140,7 @@
 
     [dir="rtl"] .interactive-enabled.generate-side .step-generate .generate-prompt-button,
     [dir="rtl"] .interactive-enabled .step-generate .generate-side .generate-prompt-button {
-      left: -21.5%;
+      left: -18.5%;
       right: auto;
     }
 


### PR DESCRIPTION
Resolves: [MWPW-156972](https://jira.corp.adobe.com/browse/MWPW-156972)

**Test URLs:**
- Before: https://main--cc--adobecom.hlx.live/products/photoshop/explore?martech=off
- After: https://mwpw-156972--cc--drashti1712.hlx.live/products/photoshop/explore?martech=off
