### PR TITLE
[MWPW-158444] Added stage domains map

### DIFF
--- a/creativecloud/scripts/scripts.js
+++ b/creativecloud/scripts/scripts.js
@@ -124,7 +124,15 @@ const locales = {
 };
 
 const stageDomainsMap = {
-  'www.stage.adobe.com': { 'www.adobe.com': 'origin' },
+  'www.stage.adobe.com': { 
+    'www.adobe.com': 'origin',
+    'business.adobe.com': 'business.stage.adobe.com',
+    'helpx.adobe.com': 'helpx.stage.adobe.com',
+    'blog.adobe.com': 'blog.stage.adobe.com',
+    'developer.adobe.com': 'developer-stage.adobe.com',
+    'news.adobe.com': 'news.stage.adobe.com',
+    'firefly.adobe.com': 'firefly-stage.corp.adobe.com',
+  },
   '--cc--adobecom.hlx.live': { 'www.adobe.com': 'origin' },
   '--cc--adobecom.hlx.page': { 'www.adobe.com': 'origin' },
 };

--- a/creativecloud/scripts/scripts.js
+++ b/creativecloud/scripts/scripts.js
@@ -135,15 +135,6 @@ const stageDomainsMap = {
   },
 };
 
-const stageDomainsMap = {
-  'business.adobe.com': 'business.stage.adobe.com',
-  'helpx.adobe.com': 'helpx.stage.adobe.com',
-  'blog.adobe.com': 'blog.stage.adobe.com',
-  'developer.adobe.com': 'developer-stage.adobe.com',
-  'news.adobe.com': 'news.stage.adobe.com',
-  'firefly.adobe.com': 'firefly-stage.corp.adobe.com',
-};
-
 // Add any config options.
 const CONFIG = {
   contentRoot: '/cc-shared',

--- a/creativecloud/scripts/scripts.js
+++ b/creativecloud/scripts/scripts.js
@@ -124,15 +124,9 @@ const locales = {
 };
 
 const stageDomainsMap = {
-  'www.stage.adobe.com': {
-    'www.adobe.com': 'origin',
-  },
-  '--cc--adobecom.hlx.live': {
-    'www.adobe.com': 'origin',
-  },
-  '--cc--adobecom.hlx.page': {
-    'www.adobe.com': 'origin',
-  },
+  'www.stage.adobe.com': { 'www.adobe.com': 'origin', },
+  '--cc--adobecom.hlx.live': { 'www.adobe.com': 'origin', },
+  '--cc--adobecom.hlx.page': { 'www.adobe.com': 'origin', },
 };
 
 // Add any config options.

--- a/creativecloud/scripts/scripts.js
+++ b/creativecloud/scripts/scripts.js
@@ -124,6 +124,18 @@ const locales = {
 };
 
 const stageDomainsMap = {
+  'www.stage.adobe.com': {
+    'www.adobe.com': 'origin',
+  },
+  '--cc--adobecom.hlx.live': {
+    'www.adobe.com': 'origin',
+  },
+  '--cc--adobecom.hlx.page': {
+    'www.adobe.com': 'origin',
+  },
+};
+
+const stageDomainsMap = {
   'business.adobe.com': 'business.stage.adobe.com',
   'helpx.adobe.com': 'helpx.stage.adobe.com',
   'blog.adobe.com': 'blog.stage.adobe.com',
@@ -170,6 +182,7 @@ const CONFIG = {
     /www\.adobe\.com\/(\w\w(_\w\w)?\/)?express(\/.*)?/,
     /www\.adobe\.com\/(\w\w(_\w\w)?\/)?go(\/.*)?/,
   ],
+  stageDomainsMap,
 };
 
 /*

--- a/creativecloud/scripts/scripts.js
+++ b/creativecloud/scripts/scripts.js
@@ -133,7 +133,7 @@ const stageDomainsMap = {
     'news.adobe.com': 'news.stage.adobe.com',
     'firefly.adobe.com': 'firefly-stage.corp.adobe.com',
   },
-  '--cc--adobecom.hlx.live': { 
+  '--cc--adobecom.hlx.live': {
     'www.adobe.com': 'origin',
     'helpx.adobe.com': 'helpx.stage.adobe.com',
     'blog.adobe.com': 'blog.stage.adobe.com',
@@ -141,7 +141,8 @@ const stageDomainsMap = {
     'news.adobe.com': 'news.stage.adobe.com',
     'firefly.adobe.com': 'firefly-stage.corp.adobe.com',
   },
-  '--cc--adobecom.hlx.page': { 'www.adobe.com': 'origin',
+  '--cc--adobecom.hlx.page': {
+    'www.adobe.com': 'origin',
     'helpx.adobe.com': 'helpx.stage.adobe.com',
     'blog.adobe.com': 'blog.stage.adobe.com',
     'developer.adobe.com': 'developer-stage.adobe.com',

--- a/creativecloud/scripts/scripts.js
+++ b/creativecloud/scripts/scripts.js
@@ -124,9 +124,9 @@ const locales = {
 };
 
 const stageDomainsMap = {
-  'www.stage.adobe.com': { 'www.adobe.com': 'origin', },
-  '--cc--adobecom.hlx.live': { 'www.adobe.com': 'origin', },
-  '--cc--adobecom.hlx.page': { 'www.adobe.com': 'origin', },
+  'www.stage.adobe.com': { 'www.adobe.com': 'origin' },
+  '--cc--adobecom.hlx.live': { 'www.adobe.com': 'origin' },
+  '--cc--adobecom.hlx.page': { 'www.adobe.com': 'origin' },
 };
 
 // Add any config options.

--- a/creativecloud/scripts/scripts.js
+++ b/creativecloud/scripts/scripts.js
@@ -133,8 +133,24 @@ const stageDomainsMap = {
     'news.adobe.com': 'news.stage.adobe.com',
     'firefly.adobe.com': 'firefly-stage.corp.adobe.com',
   },
-  '--cc--adobecom.hlx.live': { 'www.adobe.com': 'origin' },
-  '--cc--adobecom.hlx.page': { 'www.adobe.com': 'origin' },
+  '--cc--adobecom.hlx.live': { 
+    'www.adobe.com': 'origin',
+    'business.adobe.com': 'business.stage.adobe.com',
+    'helpx.adobe.com': 'helpx.stage.adobe.com',
+    'blog.adobe.com': 'blog.stage.adobe.com',
+    'developer.adobe.com': 'developer-stage.adobe.com',
+    'news.adobe.com': 'news.stage.adobe.com',
+    'firefly.adobe.com': 'firefly-stage.corp.adobe.com',
+  },
+  '--cc--adobecom.hlx.page': { 
+    'www.adobe.com': 'origin',
+    'business.adobe.com': 'business.stage.adobe.com',
+    'helpx.adobe.com': 'helpx.stage.adobe.com',
+    'blog.adobe.com': 'blog.stage.adobe.com',
+    'developer.adobe.com': 'developer-stage.adobe.com',
+    'news.adobe.com': 'news.stage.adobe.com',
+    'firefly.adobe.com': 'firefly-stage.corp.adobe.com',
+  },
 };
 
 // Add any config options.

--- a/creativecloud/scripts/scripts.js
+++ b/creativecloud/scripts/scripts.js
@@ -135,6 +135,7 @@ const stageDomainsMap = {
   },
   '--cc--adobecom.hlx.live': {
     'www.adobe.com': 'origin',
+    'business.adobe.com': 'business.stage.adobe.com',
     'helpx.adobe.com': 'helpx.stage.adobe.com',
     'blog.adobe.com': 'blog.stage.adobe.com',
     'developer.adobe.com': 'developer-stage.adobe.com',
@@ -143,6 +144,7 @@ const stageDomainsMap = {
   },
   '--cc--adobecom.hlx.page': {
     'www.adobe.com': 'origin',
+    'business.adobe.com': 'business.stage.adobe.com',
     'helpx.adobe.com': 'helpx.stage.adobe.com',
     'blog.adobe.com': 'blog.stage.adobe.com',
     'developer.adobe.com': 'developer-stage.adobe.com',

--- a/creativecloud/scripts/scripts.js
+++ b/creativecloud/scripts/scripts.js
@@ -133,24 +133,8 @@ const stageDomainsMap = {
     'news.adobe.com': 'news.stage.adobe.com',
     'firefly.adobe.com': 'firefly-stage.corp.adobe.com',
   },
-  '--cc--adobecom.hlx.live': { 
-    'www.adobe.com': 'origin',
-    'business.adobe.com': 'business.stage.adobe.com',
-    'helpx.adobe.com': 'helpx.stage.adobe.com',
-    'blog.adobe.com': 'blog.stage.adobe.com',
-    'developer.adobe.com': 'developer-stage.adobe.com',
-    'news.adobe.com': 'news.stage.adobe.com',
-    'firefly.adobe.com': 'firefly-stage.corp.adobe.com',
-  },
-  '--cc--adobecom.hlx.page': { 
-    'www.adobe.com': 'origin',
-    'business.adobe.com': 'business.stage.adobe.com',
-    'helpx.adobe.com': 'helpx.stage.adobe.com',
-    'blog.adobe.com': 'blog.stage.adobe.com',
-    'developer.adobe.com': 'developer-stage.adobe.com',
-    'news.adobe.com': 'news.stage.adobe.com',
-    'firefly.adobe.com': 'firefly-stage.corp.adobe.com',
-  },
+  '--cc--adobecom.hlx.live': { 'www.adobe.com': 'origin' },
+  '--cc--adobecom.hlx.page': { 'www.adobe.com': 'origin' },
 };
 
 // Add any config options.

--- a/creativecloud/scripts/scripts.js
+++ b/creativecloud/scripts/scripts.js
@@ -133,8 +133,21 @@ const stageDomainsMap = {
     'news.adobe.com': 'news.stage.adobe.com',
     'firefly.adobe.com': 'firefly-stage.corp.adobe.com',
   },
-  '--cc--adobecom.hlx.live': { 'www.adobe.com': 'origin' },
-  '--cc--adobecom.hlx.page': { 'www.adobe.com': 'origin' },
+  '--cc--adobecom.hlx.live': { 
+    'www.adobe.com': 'origin',
+    'helpx.adobe.com': 'helpx.stage.adobe.com',
+    'blog.adobe.com': 'blog.stage.adobe.com',
+    'developer.adobe.com': 'developer-stage.adobe.com',
+    'news.adobe.com': 'news.stage.adobe.com',
+    'firefly.adobe.com': 'firefly-stage.corp.adobe.com',
+  },
+  '--cc--adobecom.hlx.page': { 'www.adobe.com': 'origin',
+    'helpx.adobe.com': 'helpx.stage.adobe.com',
+    'blog.adobe.com': 'blog.stage.adobe.com',
+    'developer.adobe.com': 'developer-stage.adobe.com',
+    'news.adobe.com': 'news.stage.adobe.com',
+    'firefly.adobe.com': 'firefly-stage.corp.adobe.com',
+  },
 };
 
 // Add any config options.

--- a/creativecloud/scripts/scripts.js
+++ b/creativecloud/scripts/scripts.js
@@ -124,7 +124,7 @@ const locales = {
 };
 
 const stageDomainsMap = {
-  'www.stage.adobe.com': { 
+  'www.stage.adobe.com': {
     'www.adobe.com': 'origin',
     'business.adobe.com': 'business.stage.adobe.com',
     'helpx.adobe.com': 'helpx.stage.adobe.com',

--- a/creativecloud/scripts/scripts.js
+++ b/creativecloud/scripts/scripts.js
@@ -167,7 +167,6 @@ const CONFIG = {
     /www\.adobe\.com\/(\w\w(_\w\w)?\/)?express(\/.*)?/,
     /www\.adobe\.com\/(\w\w(_\w\w)?\/)?go(\/.*)?/,
   ],
-  stageDomainsMap,
 };
 
 /*


### PR DESCRIPTION
< @robert-bogos opening this PR from https://github.com/robert-bogos/cc/pull/1 >
This PR adds the stageDomainsMap, enabling the conversion of production URLs to their stage equivalents in the stage environment.
More details about this feature can be found in [this discussion](https://github.com/orgs/adobecom/discussions/2880).

Resolves: [MWPW-158444](https://jira.corp.adobe.com/browse/MWPW-158444)

Test URLs:

Before: https://main--cc--adobecom.hlx.live/careers?martech=off
After: https://mwpw-158444-domains-map--cc--adobecom.hlx.live/careers?martech=off
