### PR TITLE
MWPW-159417-Update stage domain mapping

### DIFF
--- a/creativecloud/scripts/scripts.js
+++ b/creativecloud/scripts/scripts.js
@@ -132,6 +132,8 @@ const stageDomainsMap = {
     'developer.adobe.com': 'developer-stage.adobe.com',
     'news.adobe.com': 'news.stage.adobe.com',
     'firefly.adobe.com': 'firefly-stage.corp.adobe.com',
+    'news.adobe.com': 'news.stage.adobe.com',
+    'creativecloud.adobe.com': 'stage.creativecloud.adobe.com',
   },
   '--cc--adobecom.hlx.live': {
     'www.adobe.com': 'origin',
@@ -141,6 +143,7 @@ const stageDomainsMap = {
     'developer.adobe.com': 'developer-stage.adobe.com',
     'news.adobe.com': 'news.stage.adobe.com',
     'firefly.adobe.com': 'firefly-stage.corp.adobe.com',
+    'creativecloud.adobe.com': 'stage.creativecloud.adobe.com',
   },
   '--cc--adobecom.hlx.page': {
     'www.adobe.com': 'origin',
@@ -150,6 +153,7 @@ const stageDomainsMap = {
     'developer.adobe.com': 'developer-stage.adobe.com',
     'news.adobe.com': 'news.stage.adobe.com',
     'firefly.adobe.com': 'firefly-stage.corp.adobe.com',
+    'creativecloud.adobe.com': 'stage.creativecloud.adobe.com',
   },
 };
 

--- a/creativecloud/scripts/scripts.js
+++ b/creativecloud/scripts/scripts.js
@@ -132,7 +132,6 @@ const stageDomainsMap = {
     'developer.adobe.com': 'developer-stage.adobe.com',
     'news.adobe.com': 'news.stage.adobe.com',
     'firefly.adobe.com': 'firefly-stage.corp.adobe.com',
-    'news.adobe.com': 'news.stage.adobe.com',
     'creativecloud.adobe.com': 'stage.creativecloud.adobe.com',
   },
   '--cc--adobecom.hlx.live': {

--- a/creativecloud/scripts/scripts.js
+++ b/creativecloud/scripts/scripts.js
@@ -133,6 +133,7 @@ const stageDomainsMap = {
     'news.adobe.com': 'news.stage.adobe.com',
     'firefly.adobe.com': 'firefly-stage.corp.adobe.com',
     'creativecloud.adobe.com': 'stage.creativecloud.adobe.com',
+    'projectneo.adobe.com': 'stg.projectneo.adobe.com',
   },
   '--cc--adobecom.hlx.live': {
     'www.adobe.com': 'origin',
@@ -143,6 +144,7 @@ const stageDomainsMap = {
     'news.adobe.com': 'news.stage.adobe.com',
     'firefly.adobe.com': 'firefly-stage.corp.adobe.com',
     'creativecloud.adobe.com': 'stage.creativecloud.adobe.com',
+    'projectneo.adobe.com': 'stg.projectneo.adobe.com',
   },
   '--cc--adobecom.hlx.page': {
     'www.adobe.com': 'origin',
@@ -153,6 +155,7 @@ const stageDomainsMap = {
     'news.adobe.com': 'news.stage.adobe.com',
     'firefly.adobe.com': 'firefly-stage.corp.adobe.com',
     'creativecloud.adobe.com': 'stage.creativecloud.adobe.com',
+    'projectneo.adobe.com': 'stg.projectneo.adobe.com',
   },
 };
 


### PR DESCRIPTION
* Add creative.adobe.com and projectneo.adobe.com/ to stage domain mapping

Resolves: [MWPW-159417](https://jira.corp.adobe.com/browse/MWPW-159417)

**Test URLs:**
- Before: https://stage--cc--adobecom.hlx.live/drafts/ruchika/sstage-domain?martech=off
- After: https://creativecloud--cc--adobecom.hlx.live/drafts/ruchika/sstage-domain?martech=off
