### PR TITLE
MWPW-155686 Catalog Milo: Preview Index Follow Up

### DIFF
--- a/.github/workflows/run-preview-index-single.yaml
+++ b/.github/workflows/run-preview-index-single.yaml
@@ -50,3 +50,4 @@ jobs:
           CONSUMER: ${{vars.CONSUMER}}
           PREVIEW_INDEX_FILE: ${{vars.PREVIEW_INDEX_FILE}}
           ENABLED: ${{vars.ENABLED}}
+          PREVIEW_INDEX_JSON: ${{vars.PREVIEW_INDEX_JSON}}


### PR DESCRIPTION
* Unfortunately, this still does not work 100%. It cannot be tested on feature brach so we discover problems only after PR is merged. I hope this is the last change. This time one configuration property is not passed from env variables to the JS code call. 

Resolves: [MWPW-155686](https://jira.corp.adobe.com/browse/MWPW-155686)

**Test URLs:**
- Before: https://main--cc--adobecom.hlx.live/?martech=off
- After: https://mwpw155686preview4--cc--bozojovicic.hlx.live/?martech=off
