### PR TITLE
MWPW-157433 Preload LCP resources on Catalog Page

### DIFF
--- a/creativecloud/scripts/utils.js
+++ b/creativecloud/scripts/utils.js
@@ -384,8 +384,8 @@ export const scriptInit = async () => {
   (function loadStyles() {
     const paths = [`${miloLibs}/styles/styles.css`, `${miloLibs}/blocks/text/text.js`, `${miloLibs}/blocks/text/text.css`, `${miloLibs}/blocks/mnemonic-list/mnemonic-list.css`];
     if (window.location.pathname.includes(CATALOG_PATH)) {
-      const catalogRenderBlockPaths = [`${miloLibs}/blocks/text/text.js`, `${miloLibs}/blocks/text/text.css`, `${miloLibs}/blocks/mnemonic-list/mnemonic-list.css`];
-      paths.push(...catalogRenderBlockPaths);
+      const catalogPreloadPaths = [`${miloLibs}/blocks/text/text.js`, `${miloLibs}/blocks/text/text.css`, `${miloLibs}/blocks/mnemonic-list/mnemonic-list.css`];
+      paths.push(...catalogPreloadPaths);
     }
     paths.forEach((path) => {
       const link = document.createElement('link');

--- a/creativecloud/scripts/utils.js
+++ b/creativecloud/scripts/utils.js
@@ -382,7 +382,7 @@ export const scriptInit = async () => {
   if (isSignedInHomepage) acomsisCookieHandler();
   decorateArea();
   (function loadStyles() {
-    const paths = [`${miloLibs}/styles/styles.css`, `${miloLibs}/blocks/text/text.js`, `${miloLibs}/blocks/text/text.css`, `${miloLibs}/blocks/mnemonic-list/mnemonic-list.css`];
+    const paths = [`${miloLibs}/styles/styles.css`];
     if (window.location.pathname.includes(CATALOG_PATH)) {
       const catalogPreloadPaths = [`${miloLibs}/blocks/text/text.js`, `${miloLibs}/blocks/text/text.css`, `${miloLibs}/blocks/mnemonic-list/mnemonic-list.css`];
       paths.push(...catalogPreloadPaths);

--- a/creativecloud/scripts/utils.js
+++ b/creativecloud/scripts/utils.js
@@ -17,6 +17,7 @@
 const COOKIE_SIGNED_IN = 'acomsis';
 const COOKIE_SIGNED_IN_STAGE = 'acomsis_stage';
 const CHINA_SIGNED_IN_HOME_PATH = '/cn/creativecloud/roc/home';
+const CATALOG_PATH = '/products/catalog';
 
 const locales = {
   // Americas
@@ -381,7 +382,11 @@ export const scriptInit = async () => {
   if (isSignedInHomepage) acomsisCookieHandler();
   decorateArea();
   (function loadStyles() {
-    const paths = [`${miloLibs}/styles/styles.css`];
+    const paths = [`${miloLibs}/styles/styles.css`, `${miloLibs}/blocks/text/text.js`, `${miloLibs}/blocks/text/text.css`, `${miloLibs}/blocks/mnemonic-list/mnemonic-list.css`];
+    if (window.location.pathname.includes(CATALOG_PATH)) {
+      const catalogRenderBlockPaths = [`${miloLibs}/blocks/text/text.js`, `${miloLibs}/blocks/text/text.css`, `${miloLibs}/blocks/mnemonic-list/mnemonic-list.css`];
+      paths.push(...catalogRenderBlockPaths);
+    }
     paths.forEach((path) => {
       const link = document.createElement('link');
       link.setAttribute('rel', 'stylesheet');


### PR DESCRIPTION
What @mokimo  started in https://github.com/adobecom/milo/pull/2914 
and @spadmasa continued in https://github.com/adobecom/cc/pull/433
now I will try to finish for Catalog page.
Soujanya already added preloading of utils.js for all CC pages
On top of her code I added preloading of these resources

- /libs/blocks/text/text.js
- /libs/blocks/text/text.css
- /libs/blocks/mnemonic-list/mnemonic-list.css

which are reported as critical for LCP of the catalog page.

<img width="922" alt="Screenshot 2024-11-06 at 16 27 33" src="https://github.com/user-attachments/assets/c30bdfbf-e999-4d80-a0da-7fcd7499eca5">

Resolves: [MWPW-157433](https://jira.corp.adobe.com/browse/MWPW-157433)

**Test URLs:**
- Before: https://main--cc--adobecom.hlx.live/?martech=off
- After: https://mwpw157433lcp--cc--bozojovicic.hlx.live/?martech=off
