### PR TITLE
MWPW-162305: [Black Friday] CTA not visible on CRM due to sticky banner

### DIFF
--- a/creativecloud/scripts/utils.js
+++ b/creativecloud/scripts/utils.js
@@ -122,7 +122,6 @@ const locales = {
 
 const stageDomainsMap = {
   'www.stage.adobe.com': {
-    'www.adobe.com': 'origin',
     'business.adobe.com': 'business.stage.adobe.com',
     'helpx.adobe.com': 'helpx.stage.adobe.com',
     'blog.adobe.com': 'blog.stage.adobe.com',
@@ -133,7 +132,6 @@ const stageDomainsMap = {
     'projectneo.adobe.com': 'stg.projectneo.adobe.com',
   },
   '--cc--adobecom.hlx.live': {
-    'www.adobe.com': 'origin',
     'business.adobe.com': 'business.stage.adobe.com',
     'helpx.adobe.com': 'helpx.stage.adobe.com',
     'blog.adobe.com': 'blog.stage.adobe.com',
@@ -144,7 +142,6 @@ const stageDomainsMap = {
     'projectneo.adobe.com': 'stg.projectneo.adobe.com',
   },
   '--cc--adobecom.hlx.page': {
-    'www.adobe.com': 'origin',
     'business.adobe.com': 'business.stage.adobe.com',
     'helpx.adobe.com': 'helpx.stage.adobe.com',
     'blog.adobe.com': 'blog.stage.adobe.com',


### PR DESCRIPTION
Removing www.adobe.com from stageDomainsMap to avoid transformation of modals URLs.

Resolves: 
[MWPW-162305](https://jira.corp.adobe.com/browse/MWPW-162305)
[MWPW-162339](https://jira.corp.adobe.com/browse/MWPW-162339)

**Test URLs:**
Before: 
- https://main--cc--adobecom.hlx.page/creativecloud/plan-recommender/quiz-results?quizkey=cc-quiz&martech=off&georouting=off 
- https://main--cc--adobecom.hlx.page/ca/products/aftereffects?instant=2024-11-15T14:00:00.000Z

After: 
- https://mwpw-162305-modal-sticky-banner  --cc--adobecom.hlx.page/creativecloud/plan-recommender/quiz-results?quizkey=cc-quiz&martech=off&georouting=off 
- https://mwpw-162305-modal-sticky-banner  --cc--adobecom.hlx.page/ca/products/aftereffects?milolibs=mwpw-162305-modal-sticky-banner--milo--mirafedas&instant=2024-11-15T14:00:00.000Z
(Added spaces after branch name to make links invisible for PSI check, this change does not influence performance)

For PSI check:
https://mwpw-162305-modal-sticky-banner--cc--adobecom.hlx.live/careers?martech=off&georouting=off
