### PR TITLE
MWPW-162305 Modal domain switch

### DIFF
--- a/creativecloud/scripts/utils.js
+++ b/creativecloud/scripts/utils.js
@@ -154,17 +154,6 @@ const stageDomainsMap = {
     'creativecloud.adobe.com': 'stage.creativecloud.adobe.com',
     'projectneo.adobe.com': 'stg.projectneo.adobe.com',
   },
-  '--cc--bozojovicic.hlx.page': {
-    'www.adobe.com(?!\\/*\\S*\\/(mini-plans|plans-fragments\\/modals)\\/\\S*)': 'origin',
-    'business.adobe.com': 'business.stage.adobe.com',
-    'helpx.adobe.com': 'helpx.stage.adobe.com',
-    'blog.adobe.com': 'blog.stage.adobe.com',
-    'developer.adobe.com': 'developer-stage.adobe.com',
-    'news.adobe.com': 'news.stage.adobe.com',
-    'firefly.adobe.com': 'firefly-stage.corp.adobe.com',
-    'creativecloud.adobe.com': 'stage.creativecloud.adobe.com',
-    'projectneo.adobe.com': 'stg.projectneo.adobe.com',
-  },
 };
 
 /**

--- a/creativecloud/scripts/utils.js
+++ b/creativecloud/scripts/utils.js
@@ -122,7 +122,7 @@ const locales = {
 
 const stageDomainsMap = {
   'www.stage.adobe.com': {
-    'www.adobe.com': 'origin',
+    'www.adobe.com(?!\\/*\\S*\\/(mini-plans|plans-fragments\\/modals)\\/\\S*)': 'origin',
     'business.adobe.com': 'business.stage.adobe.com',
     'helpx.adobe.com': 'helpx.stage.adobe.com',
     'blog.adobe.com': 'blog.stage.adobe.com',
@@ -133,7 +133,7 @@ const stageDomainsMap = {
     'projectneo.adobe.com': 'stg.projectneo.adobe.com',
   },
   '--cc--adobecom.hlx.live': {
-    'www.adobe.com': 'origin',
+    'www.adobe.com(?!\\/*\\S*\\/(mini-plans|plans-fragments\\/modals)\\/\\S*)': 'origin',
     'business.adobe.com': 'business.stage.adobe.com',
     'helpx.adobe.com': 'helpx.stage.adobe.com',
     'blog.adobe.com': 'blog.stage.adobe.com',
@@ -144,7 +144,18 @@ const stageDomainsMap = {
     'projectneo.adobe.com': 'stg.projectneo.adobe.com',
   },
   '--cc--adobecom.hlx.page': {
-    'www.adobe.com': 'origin',
+    'www.adobe.com(?!\\/*\\S*\\/(mini-plans|plans-fragments\\/modals)\\/\\S*)': 'origin',
+    'business.adobe.com': 'business.stage.adobe.com',
+    'helpx.adobe.com': 'helpx.stage.adobe.com',
+    'blog.adobe.com': 'blog.stage.adobe.com',
+    'developer.adobe.com': 'developer-stage.adobe.com',
+    'news.adobe.com': 'news.stage.adobe.com',
+    'firefly.adobe.com': 'firefly-stage.corp.adobe.com',
+    'creativecloud.adobe.com': 'stage.creativecloud.adobe.com',
+    'projectneo.adobe.com': 'stg.projectneo.adobe.com',
+  },
+  '--cc--bozojovicic.hlx.page': {
+    'www.adobe.com(?!\\/*\\S*\\/(mini-plans|plans-fragments\\/modals)\\/\\S*)': 'origin',
     'business.adobe.com': 'business.stage.adobe.com',
     'helpx.adobe.com': 'helpx.stage.adobe.com',
     'blog.adobe.com': 'blog.stage.adobe.com',

--- a/test/scripts/scripts.test.js
+++ b/test/scripts/scripts.test.js
@@ -23,7 +23,7 @@ describe('Scripts', () => {
   });
 
   it('Check domain switch regexp', () => {
-    const regex = /www.adobe.com(?!\/*\S*\/(mini-plans|plans-fragments\/modals)\/\S*)/;
+    const regex = /www\.adobe\.com(?!\/*\S*\/(mini-plans|plans-fragments\/modals)\/\S*)/;
     // should not switch domain
     expect(regex.test('https://www.adobe.com/mini-plans/photoshop.html?mid=ft&web=1')).to.false;
     expect(regex.test('https://www.adobe.com/de/mini-plans/photoshop.html?mid=ft&web=1')).to.false;

--- a/test/scripts/scripts.test.js
+++ b/test/scripts/scripts.test.js
@@ -23,7 +23,7 @@ describe('Scripts', () => {
   });
 
   it('Check domain switch regexp', () => {
-    const regex = new RegExp('www.adobe.com(?!\\/*\\S*\\/(mini-plans|plans-fragments\\/modals)\\/\\S*)');
+    const regex = /www.adobe.com(?!\/*\S*\/(mini-plans|plans-fragments\/modals)\/\S*)/;
     // should not switch domain
     expect(regex.test('https://www.adobe.com/mini-plans/photoshop.html?mid=ft&web=1')).to.false;
     expect(regex.test('https://www.adobe.com/de/mini-plans/photoshop.html?mid=ft&web=1')).to.false;

--- a/test/scripts/scripts.test.js
+++ b/test/scripts/scripts.test.js
@@ -21,4 +21,20 @@ describe('Scripts', () => {
   it('Replaced dot media', () => {
     expect(document.querySelector('.interactive-marquee img[src*="./media_"]')).to.be.null;
   });
+
+  it('Check domain switch regexp', () => {
+    const regex = new RegExp('www.adobe.com(?!\\/*\\S*\\/(mini-plans|plans-fragments\\/modals)\\/\\S*)');
+    // should not switch domain
+    expect(regex.test('https://www.adobe.com/mini-plans/photoshop.html?mid=ft&web=1')).to.false;
+    expect(regex.test('https://www.adobe.com/de/mini-plans/photoshop.html?mid=ft&web=1')).to.false;
+    expect(regex.test('https://www.adobe.com/plans-fragments/modals/business/modals-content-rich/all-apps/master.modal.html')).to.false;
+    expect(regex.test('https://www.adobe.com/fr/plans-fragments/modals/business/modals-content-rich/all-apps/master.modal.html')).to.false;
+    // should switch domain
+    expect(regex.test('https://www.adobe.com/fr/plans-fragments/business/modals-content-rich/all-apps/master.modal.html')).to.true;
+    expect(regex.test('https://www.adobe.com/de/mega-plans/photoshop.html?mid=ft&web=1')).to.true;
+    expect(regex.test('https://www.adobe.com/creativecloud/plans.html')).to.true;
+    expect(regex.test('https://www.adobe.com/products/catalog.html')).to.true;
+    expect(regex.test('https://www.adobe.com/creativecloud/whats-included/plans/cct-all-apps-whats-included.html')).to.true;
+    expect(regex.test('https://www.adobe.com/de/creativecloud/whats-included/plans/cct-all-apps-whats-included.html')).to.true;
+  });
 });


### PR DESCRIPTION
On preview page, we need to change the domain of all links from adobe.com to the preview domain *--cc--adobecom.hlx.page except for TWP and CRM links. They need to stay on adobe.com since we have them only on that domain.

With `'www.adobe.com': 'origin'` we were replacing adobe.com with the origin in all links.
Now with `'www.adobe.com(?!\\/*\\S*\\/(mini-plans|plans-fragments\\/modals)\\/\\S*)': 'origin'` the domain will not be replaced for TWP and CRM links.

Test page: /drafts/bozo/modal-domain-test

Resolves: [MWPW-162305](https://jira.corp.adobe.com/browse/MWPW-162305)

**Test URLs:**
- Before: https://main--cc--adobecom.hlx.live/?martech=off
- After: https://mwpw162305modaldomain--cc--adobecom.hlx.live/?martech=off
