### PR TITLE
MWPW-161504: [Milo Plans Page] Footer banner callout block

### DIFF
--- a/creativecloud/blocks/callout/callout.css
+++ b/creativecloud/blocks/callout/callout.css
@@ -1,0 +1,28 @@
+.callout {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-m);
+  padding: var(--spacing-m);
+}
+
+.callout-item {
+  padding: var(--spacing-s);
+  text-align: center;
+  border: 1px solid #E1E1E1;
+  font-size: var(--type-body-m-size);
+  border-radius: 16px;
+}
+
+.callout-item p:first-of-type {
+  margin-block-start: 0;
+}
+
+.callout-item p:last-of-type {
+  margin-block-end: 0;
+}
+
+@media screen and (min-width: 1200px) {
+  .callout {
+    flex-direction: row;
+  }
+}

--- a/creativecloud/blocks/callout/callout.js
+++ b/creativecloud/blocks/callout/callout.js
@@ -5,8 +5,8 @@ const groupElementsIntoBlocks = (container, createTag) => {
   const blocks = [];
 
   if (!elements.length) {
-    // one block with only one paragraph
-    const content = container.querySelector('div > div > div > div')?.innerHTML;
+    // one block with one paragraph
+    const content = container.querySelector('div > div > div')?.innerHTML;
     if (content) blocks.push(createTag('div', { class: 'callout-item' }, createTag('p', false, content)));
     return blocks;
   }

--- a/creativecloud/blocks/callout/callout.js
+++ b/creativecloud/blocks/callout/callout.js
@@ -1,0 +1,41 @@
+import { getLibs } from '../../scripts/utils.js';
+
+const groupElementsIntoBlocks = (container, createTag) => {
+  const elements = container.querySelectorAll('p, hr');
+  const blocks = [];
+
+  if (!elements.length) {
+    // one block with only one paragraph
+    const content = container.querySelector('div > div > div > div')?.innerHTML;
+    if (content) blocks.push(createTag('div', { class: 'callout-item' }, createTag('p', false, content)));
+    return blocks;
+  }
+
+  const hrIndexes = [...elements].reduce((indexes, el, i) => {
+    if (el.tagName === 'HR') indexes.push(i);
+    return indexes;
+  }, []);
+
+  if (!hrIndexes.length) {
+    // one block with multiple paragraphs
+    blocks.push(createTag('div', { class: 'callout-item' }, [...elements]));
+  } else {
+    // more than one block
+    let start = 0;
+    hrIndexes.forEach((end) => {
+      blocks.push(createTag('div', { class: 'callout-item' }, [...elements].slice(start, end)));
+      start = end + 1;
+    });
+    blocks.push(createTag('div', { class: 'callout-item' }, [...elements].slice(start)));
+  }
+
+  return blocks;
+};
+
+export default async function init(el) {
+  const miloLibs = getLibs('/libs');
+  const { createTag, getConfig, loadStyle } = await import(`${miloLibs}/utils/utils.js`);
+  loadStyle(`${getConfig().base}/blocks/callout/callout.css`);
+  const blocks = groupElementsIntoBlocks(el, createTag);
+  el.replaceChildren(...blocks);
+}

--- a/test/blocks/callout/callout.test.js
+++ b/test/blocks/callout/callout.test.js
@@ -6,51 +6,39 @@ const { setLibs } = await import('../../../creativecloud/scripts/utils.js');
 const { default: init } = await import('../../../creativecloud/blocks/callout/callout.js');
 
 describe('callout block', () => {
-  let oneBlockOneParagraph;
-  let oneBlockTwoParagraphs;
-  let twoBlocks;
-  let threeBlocks;
+  const oneBlockOneParagraph = document.querySelector('#one-block-one-paragraph');
+  const oneBlockTwoParagraphs = document.querySelector('#one-block-two-paragraphs');
+  const twoBlocks = document.querySelector('#two-blocks');
+
   before(async () => {
     setLibs('https://milo.adobe.com/libs');
-    oneBlockOneParagraph = document.querySelector('#one-block-one-paragraph');
-    oneBlockTwoParagraphs = document.querySelector('#one-block-two-paragraphs');
-    twoBlocks = document.querySelector('#two-blocks');
-    threeBlocks = document.querySelector('#three-blocks');
     await Promise.all(
-      [oneBlockOneParagraph, oneBlockTwoParagraphs, twoBlocks, threeBlocks].map((el) => init(el)),
+      [oneBlockOneParagraph, oneBlockTwoParagraphs, twoBlocks].map((el) => init(el)),
     );
   });
 
-  it('dummy test', () => {
-    expect(oneBlockOneParagraph).to.exist;
-    expect(oneBlockTwoParagraphs).to.exist;
-    expect(twoBlocks).to.exist;
-    expect(threeBlocks).to.exist;
+  it('generates one block with one paragraph', () => {
+    expect(oneBlockOneParagraph.querySelector('.callout-item')).to.exist;
+    const blocks = oneBlockOneParagraph.querySelectorAll('.callout-item');
+    expect(blocks.length).to.equal(1);
+    const paragraphs = blocks[0].querySelectorAll('p');
+    expect(paragraphs.length === 1).to.be.true;
+    expect(paragraphs[0].innerHTML).to.equal('<strong class="tracking-header">Buying for a team?</strong> Easy-to-use license management. Dedicated 24/7 technical support. <a href="https://www.adobe.com/creativecloud/plans.html?plan=team" daa-ll="See all business pla-1--Buying for a team">See all business plans</a>');
   });
 
-  // it('generates one block and one paragraph', () => {
-  //   expect(oneBlockOneParagraph.querySelector('.callout-item')).to.exist;
-  //   const blocks = oneBlockOneParagraph.querySelectorAll('.callout-item');
-  //   expect(blocks.length).to.equal(1);
-  //   const paragraphs = blocks[0].querySelectorAll('p');
-  //   expect(paragraphs.length === 1).to.be.true;
-  //   expect(paragraphs[0].innerHTML).to.equal('<strong class="tracking-header">Buying for a team?</strong> Easy-to-use license management. Dedicated 24/7 technical support. <a href="https://www.adobe.com/creativecloud/plans.html?plan=team" daa-ll="See all business pla-1--Buying for a team">See all business plans</a>');
-  // });
+  it('generates one block with two paragraphs', () => {
+    const blocks = oneBlockTwoParagraphs.querySelectorAll('.callout-item');
+    expect(blocks.length === 1).to.be.true;
+    const paragraphs = blocks[0].querySelectorAll('p');
+    expect(paragraphs.length === 2).to.be.true;
+    expect(paragraphs[0].innerHTML).to.equal('<strong class="tracking-header">Buying for a team?</strong> Easy-to-use license management.');
+    expect(paragraphs[1].innerHTML).to.equal('Dedicated 24/7 technical support. <a href="https://www.adobe.com/creativecloud/plans.html?plan=team" daa-ll="See all business pla-1--Buying for a team">See all business plans</a>');
+  });
 
-  // it('generates one block and two paragraphs', async () => {
-  //   const blocks = oneBlockTwoParagraphs.querySelectorAll('.callout-item');
-  //   expect(blocks.length === 1).to.be.true;
-  //   const paragraphs = blocks[0].querySelectorAll('p');
-  //   expect(paragraphs.length === 2).to.be.true;
-  //   expect(paragraphs[0].innerHTML).to.equal('<strong class="tracking-header">
-  // Buying for a team?</strong> Easy-to-use license management.');
-  //   expect(paragraphs[1].innerHTML).to.equal('Dedicated 24/7 technical support. <a href="https://www.adobe.com/creativecloud/plans.html?plan=team" daa-ll="See all business pla-1--Buying for a team">See all business plans</a>');
-  // });
-
-  // it('generates two blocks', async () => {
-  //   const blocks = twoBlocks.querySelectorAll('.callout-item');
-  //   expect(blocks.length === 2).to.be.true;
-  //   expect(blocks[0].innerHTML).to.equal('<p><strong class="tracking-header">Buying for a team?</strong> Easy-to-use license management. Dedicated 24/7 technical support. <a href="https://www.adobe.com/creativecloud/plans.html?plan=team" daa-ll="See all business pla-1--Buying for a team">See all business plans</a></p>');
-  //   expect(blocks[1].innerHTML).to.equal('<div class="callout-item"><p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p><p>Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.<br><a href="https://www.adobe.com/creativecloud/plans.html?plan=team" daa-ll="CTA-2--Buying for a team">CTA</a></p>');
-  // });
+  it('generates two blocks', () => {
+    const blocks = twoBlocks.querySelectorAll('.callout-item');
+    expect(blocks.length === 2).to.be.true;
+    expect(blocks[0].innerHTML).to.equal('<p><strong class="tracking-header">Buying for a team?</strong> Easy-to-use license management. Dedicated 24/7 technical support. <a href="https://www.adobe.com/creativecloud/plans.html?plan=team" daa-ll="See all business pla-1--Buying for a team">See all business plans</a></p>');
+    expect(blocks[1].innerHTML).to.equal('<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p><p>Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.<br><a href="https://www.adobe.com/creativecloud/plans.html?plan=team" daa-ll="CTA-2--Buying for a team">CTA</a></p>');
+  });
 });

--- a/test/blocks/callout/callout.test.js
+++ b/test/blocks/callout/callout.test.js
@@ -1,0 +1,56 @@
+import { readFile } from '@web/test-runner-commands';
+import { expect } from '@esm-bundle/chai';
+
+document.body.innerHTML = await readFile({ path: './mocks/body.html' });
+const { setLibs } = await import('../../../creativecloud/scripts/utils.js');
+const { default: init } = await import('../../../creativecloud/blocks/callout/callout.js');
+
+describe('callout block', () => {
+  let oneBlockOneParagraph;
+  let oneBlockTwoParagraphs;
+  let twoBlocks;
+  let threeBlocks;
+  before(async () => {
+    setLibs('https://milo.adobe.com/libs');
+    oneBlockOneParagraph = document.querySelector('#one-block-one-paragraph');
+    oneBlockTwoParagraphs = document.querySelector('#one-block-two-paragraphs');
+    twoBlocks = document.querySelector('#two-blocks');
+    threeBlocks = document.querySelector('#three-blocks');
+    await Promise.all(
+      [oneBlockOneParagraph, oneBlockTwoParagraphs, twoBlocks, threeBlocks].map((el) => init(el)),
+    );
+  });
+
+  it('dummy test', () => {
+    expect(oneBlockOneParagraph).to.exist;
+    expect(oneBlockTwoParagraphs).to.exist;
+    expect(twoBlocks).to.exist;
+    expect(threeBlocks).to.exist;
+  });
+
+  // it('generates one block and one paragraph', () => {
+  //   expect(oneBlockOneParagraph.querySelector('.callout-item')).to.exist;
+  //   const blocks = oneBlockOneParagraph.querySelectorAll('.callout-item');
+  //   expect(blocks.length).to.equal(1);
+  //   const paragraphs = blocks[0].querySelectorAll('p');
+  //   expect(paragraphs.length === 1).to.be.true;
+  //   expect(paragraphs[0].innerHTML).to.equal('<strong class="tracking-header">Buying for a team?</strong> Easy-to-use license management. Dedicated 24/7 technical support. <a href="https://www.adobe.com/creativecloud/plans.html?plan=team" daa-ll="See all business pla-1--Buying for a team">See all business plans</a>');
+  // });
+
+  // it('generates one block and two paragraphs', async () => {
+  //   const blocks = oneBlockTwoParagraphs.querySelectorAll('.callout-item');
+  //   expect(blocks.length === 1).to.be.true;
+  //   const paragraphs = blocks[0].querySelectorAll('p');
+  //   expect(paragraphs.length === 2).to.be.true;
+  //   expect(paragraphs[0].innerHTML).to.equal('<strong class="tracking-header">
+  // Buying for a team?</strong> Easy-to-use license management.');
+  //   expect(paragraphs[1].innerHTML).to.equal('Dedicated 24/7 technical support. <a href="https://www.adobe.com/creativecloud/plans.html?plan=team" daa-ll="See all business pla-1--Buying for a team">See all business plans</a>');
+  // });
+
+  // it('generates two blocks', async () => {
+  //   const blocks = twoBlocks.querySelectorAll('.callout-item');
+  //   expect(blocks.length === 2).to.be.true;
+  //   expect(blocks[0].innerHTML).to.equal('<p><strong class="tracking-header">Buying for a team?</strong> Easy-to-use license management. Dedicated 24/7 technical support. <a href="https://www.adobe.com/creativecloud/plans.html?plan=team" daa-ll="See all business pla-1--Buying for a team">See all business plans</a></p>');
+  //   expect(blocks[1].innerHTML).to.equal('<div class="callout-item"><p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p><p>Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.<br><a href="https://www.adobe.com/creativecloud/plans.html?plan=team" daa-ll="CTA-2--Buying for a team">CTA</a></p>');
+  // });
+});

--- a/test/blocks/callout/mocks/body.html
+++ b/test/blocks/callout/mocks/body.html
@@ -1,39 +1,26 @@
 <div class="callout" id="one-block-one-paragraph" data-block-status="loaded" daa-lh="b2|callout">
   <div>
-    <div data-valign="middle"><strong class="tracking-header">Buying for a team?</strong> Easy-to-use license management. Dedicated 24/7 technical support. <a href="https://www.adobe.com/creativecloud/plans.html?plan=team" daa-ll="See all business pla-1--Buying for a team">See all business plans</a></div>
+     <div data-valign="middle"><strong class="tracking-header">Buying for a team?</strong> Easy-to-use license management. Dedicated 24/7 technical support. <a href="https://www.adobe.com/creativecloud/plans.html?plan=team" daa-ll="See all business pla-1--Buying for a team">See all business plans</a></div>
   </div>
 </div>
 
 <div id="one-block-two-paragraphs" class="callout" data-block-status="loaded" daa-lh="b2|callout">
   <div>
-    <div data-valign="middle">
-      <p><strong class="tracking-header">Buying for a team?</strong> Easy-to-use license management.</p>
-      <p>Dedicated 24/7 technical support. <a href="https://www.adobe.com/creativecloud/plans.html?plan=team" daa-ll="See all business pla-1--Buying for a team">See all business plans</a></p>
-    </div>
+     <div data-valign="middle">
+        <p><strong class="tracking-header">Buying for a team?</strong> Easy-to-use license management.</p>
+        <p>Dedicated 24/7 technical support. <a href="https://www.adobe.com/creativecloud/plans.html?plan=team" daa-ll="See all business pla-1--Buying for a team">See all business plans</a></p>
+     </div>
   </div>
 </div>
 
 <div id="two-blocks" class="callout" data-block-status="loaded" daa-lh="b2|callout">
   <div>
-    <div data-valign="middle">
-      <p><strong class="tracking-header">Buying for a team?</strong> Easy-to-use license management. Dedicated 24/7 technical support. <a href="https://www.adobe.com/creativecloud/plans.html?plan=team" daa-ll="See all business pla-1--Buying for a team">See all business plans</a></p>
-      <hr>
-      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
-      <p>Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.<br><a href="https://www.adobe.com/creativecloud/plans.html?plan=team" daa-ll="CTA-2--Buying for a team">CTA</a></p>
-    </div>
+     <div data-valign="middle">
+        <p><strong class="tracking-header">Buying for a team?</strong> Easy-to-use license management. Dedicated 24/7 technical support. <a href="https://www.adobe.com/creativecloud/plans.html?plan=team" daa-ll="See all business pla-1--Buying for a team">See all business plans</a></p>
+        <hr>
+        <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
+        <p>Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.<br><a href="https://www.adobe.com/creativecloud/plans.html?plan=team" daa-ll="CTA-2--Buying for a team">CTA</a></p>
+     </div>
   </div>
 </div>
-
-<div id="three-blocks" class="callout" data-block-status="loaded" daa-lh="b2|callout">
-  <div>
-    <div data-valign="middle">
-      <p><strong class="tracking-header">Buying for a team?</strong> Easy-to-use license management. Dedicated 24/7 technical support. <a href="https://www.adobe.com/creativecloud/plans.html?plan=team" daa-ll="See all business pla-1--Buying for a team">See all business plans</a></p>
-      <hr>
-      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
-      <p>Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.<br><a href="https://www.adobe.com/creativecloud/plans.html?plan=team" daa-ll="CTA-2--Buying for a team">CTA</a></p>
-      <hr>
-      <p>Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.</p>
-      <p>Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum<br><a href="https://www.adobe.com/creativecloud/plans.html?plan=team" daa-ll="CTA1-3--Buying for a team">CTA1</a><br><a href="https://www.adobe.com/creativecloud/plans.html?plan=team" daa-ll="CTA with long text-4--Buying for a team">CTA with long text</a></p>
-    </div>
-  </div>
 </div>

--- a/test/blocks/callout/mocks/body.html
+++ b/test/blocks/callout/mocks/body.html
@@ -1,0 +1,39 @@
+<div class="callout" id="one-block-one-paragraph" data-block-status="loaded" daa-lh="b2|callout">
+  <div>
+    <div data-valign="middle"><strong class="tracking-header">Buying for a team?</strong> Easy-to-use license management. Dedicated 24/7 technical support. <a href="https://www.adobe.com/creativecloud/plans.html?plan=team" daa-ll="See all business pla-1--Buying for a team">See all business plans</a></div>
+  </div>
+</div>
+
+<div id="one-block-two-paragraphs" class="callout" data-block-status="loaded" daa-lh="b2|callout">
+  <div>
+    <div data-valign="middle">
+      <p><strong class="tracking-header">Buying for a team?</strong> Easy-to-use license management.</p>
+      <p>Dedicated 24/7 technical support. <a href="https://www.adobe.com/creativecloud/plans.html?plan=team" daa-ll="See all business pla-1--Buying for a team">See all business plans</a></p>
+    </div>
+  </div>
+</div>
+
+<div id="two-blocks" class="callout" data-block-status="loaded" daa-lh="b2|callout">
+  <div>
+    <div data-valign="middle">
+      <p><strong class="tracking-header">Buying for a team?</strong> Easy-to-use license management. Dedicated 24/7 technical support. <a href="https://www.adobe.com/creativecloud/plans.html?plan=team" daa-ll="See all business pla-1--Buying for a team">See all business plans</a></p>
+      <hr>
+      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
+      <p>Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.<br><a href="https://www.adobe.com/creativecloud/plans.html?plan=team" daa-ll="CTA-2--Buying for a team">CTA</a></p>
+    </div>
+  </div>
+</div>
+
+<div id="three-blocks" class="callout" data-block-status="loaded" daa-lh="b2|callout">
+  <div>
+    <div data-valign="middle">
+      <p><strong class="tracking-header">Buying for a team?</strong> Easy-to-use license management. Dedicated 24/7 technical support. <a href="https://www.adobe.com/creativecloud/plans.html?plan=team" daa-ll="See all business pla-1--Buying for a team">See all business plans</a></p>
+      <hr>
+      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
+      <p>Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.<br><a href="https://www.adobe.com/creativecloud/plans.html?plan=team" daa-ll="CTA-2--Buying for a team">CTA</a></p>
+      <hr>
+      <p>Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.</p>
+      <p>Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum<br><a href="https://www.adobe.com/creativecloud/plans.html?plan=team" daa-ll="CTA1-3--Buying for a team">CTA1</a><br><a href="https://www.adobe.com/creativecloud/plans.html?plan=team" daa-ll="CTA with long text-4--Buying for a team">CTA with long text</a></p>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
Adding a callout block which is used in the plans page footer.

Resolves: [MWPW-161504](https://jira.corp.adobe.com/browse/MWPW-161504)

**Test URLs:**
Before: 
- https://main--cc--adobecom.hlx.live/drafts/mirafedas/plans/callout/callout-1?martech=off (one block with one paragraph)
- https://main--cc--adobecom.hlx.live/drafts/mirafedas/plans/callout/callout-11?martech=off (one block with two paragraphs)
- https://main--adobecom.hlx.live/drafts/mirafedas/plans/callout/callout-2?martech=off (two blocks)
- https://main--adobecom.hlx.live/drafts/mirafedas/plans/callout/callout-3?martech=off (three blocks)

After: 
- https://mwpw-161504-callout-block--cc--adobecom.hlx.live/drafts/mirafedas/plans/callout/callout-1?martech=off (one block with one paragraph)
- https://mwpw-161504-callout-block--cc--adobecom.hlx.live/drafts/mirafedas/plans/callout/callout-11?martech=off (one block with two paragraphs)
- https://mwpw-161504-callout-block--cc--adobecom.hlx.live/drafts/mirafedas/plans/callout/callout-2?martech=off (two blocks)
- https://mwpw-161504-callout-block--cc--adobecom.hlx.live/drafts/mirafedas/plans/callout/callout-3?martech=off (three blocks)

