### PR TITLE
MWPW-165276- Exclude /content/dam/cc paths from getting transformed as per environment

### DIFF
--- a/creativecloud/scripts/utils.js
+++ b/creativecloud/scripts/utils.js
@@ -122,7 +122,7 @@ const locales = {
 
 const stageDomainsMap = {
   'www.stage.adobe.com': {
-    'www.adobe.com(?!\\/*\\S*\\/(mini-plans|plans-fragments\\/modals|content\/dam\/cc)\\/\\S*)': 'origin',
+    'www.adobe.com(?!\\/*\\S*\\/(mini-plans|plans-fragments\\/modals|content\\/dam\\/cc)\\/\\S*)': 'origin',
     'business.adobe.com': 'business.stage.adobe.com',
     'helpx.adobe.com': 'helpx.stage.adobe.com',
     'blog.adobe.com': 'blog.stage.adobe.com',
@@ -133,7 +133,7 @@ const stageDomainsMap = {
     'projectneo.adobe.com': 'stg.projectneo.adobe.com',
   },
   '--cc--adobecom.hlx.live': {
-    'www.adobe.com(?!\\/*\\S*\\/(mini-plans|plans-fragments\\/modals|content\/dam\/cc)\\/\\S*)': 'origin',
+    'www.adobe.com(?!\\/*\\S*\\/(mini-plans|plans-fragments\\/modals|content\\/dam\\/cc)\\/\\S*)': 'origin',
     'business.adobe.com': 'business.stage.adobe.com',
     'helpx.adobe.com': 'helpx.stage.adobe.com',
     'blog.adobe.com': 'blog.stage.adobe.com',
@@ -144,7 +144,7 @@ const stageDomainsMap = {
     'projectneo.adobe.com': 'stg.projectneo.adobe.com',
   },
   '--cc--adobecom.hlx.page': {
-    'www.adobe.com(?!\\/*\\S*\\/(mini-plans|plans-fragments\\/modals|content\/dam\/cc)\\/\\S*)': 'origin',
+    'www.adobe.com(?!\\/*\\S*\\/(mini-plans|plans-fragments\\/modals|content\\/dam\\/cc)\\/\\S*)': 'origin',
     'business.adobe.com': 'business.stage.adobe.com',
     'helpx.adobe.com': 'helpx.stage.adobe.com',
     'blog.adobe.com': 'blog.stage.adobe.com',

--- a/creativecloud/scripts/utils.js
+++ b/creativecloud/scripts/utils.js
@@ -122,7 +122,7 @@ const locales = {
 
 const stageDomainsMap = {
   'www.stage.adobe.com': {
-    'www.adobe.com(?!\\/*\\S*\\/(mini-plans|plans-fragments\\/modals)\\/\\S*)': 'origin',
+    'www.adobe.com(?!\\/*\\S*\\/(mini-plans|plans-fragments\\/modals|content\/dam\/cc)\\/\\S*)': 'origin',
     'business.adobe.com': 'business.stage.adobe.com',
     'helpx.adobe.com': 'helpx.stage.adobe.com',
     'blog.adobe.com': 'blog.stage.adobe.com',
@@ -133,7 +133,7 @@ const stageDomainsMap = {
     'projectneo.adobe.com': 'stg.projectneo.adobe.com',
   },
   '--cc--adobecom.hlx.live': {
-    'www.adobe.com(?!\\/*\\S*\\/(mini-plans|plans-fragments\\/modals)\\/\\S*)': 'origin',
+    'www.adobe.com(?!\\/*\\S*\\/(mini-plans|plans-fragments\\/modals|content\/dam\/cc)\\/\\S*)': 'origin',
     'business.adobe.com': 'business.stage.adobe.com',
     'helpx.adobe.com': 'helpx.stage.adobe.com',
     'blog.adobe.com': 'blog.stage.adobe.com',
@@ -144,7 +144,7 @@ const stageDomainsMap = {
     'projectneo.adobe.com': 'stg.projectneo.adobe.com',
   },
   '--cc--adobecom.hlx.page': {
-    'www.adobe.com(?!\\/*\\S*\\/(mini-plans|plans-fragments\\/modals)\\/\\S*)': 'origin',
+    'www.adobe.com(?!\\/*\\S*\\/(mini-plans|plans-fragments\\/modals|content\/dam\/cc)\\/\\S*)': 'origin',
     'business.adobe.com': 'business.stage.adobe.com',
     'helpx.adobe.com': 'helpx.stage.adobe.com',
     'blog.adobe.com': 'blog.stage.adobe.com',


### PR DESCRIPTION
* Exclude /content/dam/cc paths from getting transformed as per environment

Resolves: [MWPW-165276](https://jira.corp.adobe.com/browse/MWPW-165276)

**Test URLs:**
- Before: https://stage--cc--adobecom.hlx.live/drafts/ruchika/frame-io-soc3-report?martech=off
- After: https://MWPW-165276--cc--adobecom.hlx.live/drafts/ruchika/frame-io-soc3-report?martech=off
