### PR TITLE
Hide the Demandbase Popover when the API has no valid response -- bug fix

### DIFF
--- a/creativecloud/features/cc-forms/forms/demandbase.js
+++ b/creativecloud/features/cc-forms/forms/demandbase.js
@@ -131,8 +131,10 @@ class DemandBase {
     })
       .then((response) => response.json())
       .then((json) => {
-        this.fillList(e, json);
-        this.popoverShow(e);
+        if (json.picks?.length) {
+          this.fillList(e, json);
+          this.popoverShow(e);
+        }
       })
       .catch((err) => console.error('Parsing failed:', err));
   }


### PR DESCRIPTION
* Fix for not showing the Demandbase Popover when the API has no valid response

Resolves: [MWPW-164488](https://jira.corp.adobe.com/browse/MWPW-164488) (partly)

**Test URLs:**
- Before: https://ccqa--cc--adobecom.hlx.live/drafts/mathuria/dalpforms/perpeptual?martech=off
- After: https://demandbase-fix--cc--adobecom.hlx.live/drafts/mathuria/dalpforms/perpeptual?martech=off
