### PR TITLE
MWPW-164488 - When the country seen populated with the demand base selection the state field is not seen getting enabled - Fix

### DIFF
--- a/creativecloud/features/cc-forms/forms/demandbase.js
+++ b/creativecloud/features/cc-forms/forms/demandbase.js
@@ -185,7 +185,7 @@ class DemandBase {
       }
       const fieldName = fieldMapping[key];
       const fieldValue = this.convert(itemData[fieldName], fieldName);
-      if (fieldName && (fieldName.indexOf('.') !== -1 || document.querySelector(`[name=${fieldName}]:disabled`))) {
+      if (fieldName && (fieldName.indexOf('.') !== -1)) {
         return;
       }
 
@@ -197,6 +197,8 @@ class DemandBase {
         op.text = fieldValue;
         selectEl.add(op);
         selectEl.value = op.value;
+        op.removeAttribute('disabled');
+        selectEl.removeAttribute('disabled');
       }
 
       if (fieldName === 'country') {


### PR DESCRIPTION
* [Demandbase] Enables 'Disabled' field for prepopulating the value based on parent field

Resolves: [MWPW-164488](https://jira.corp.adobe.com/browse/MWPW-164488)

**Test URLs:**
- Before: https://main--cc--adobecom.hlx.live/drafts/suhjain/forms/connect?martech=off
- After: https://demandbase-fix-2--cc--adobecom.hlx.live/drafts/suhjain/forms/connect?martech=off