### PR TITLE
MWPW-162026 [Milo][Sev2][Catalog] Group of checkboxes is missing FIELDSET …

### DIFF
--- a/creativecloud/blocks/catalog/catalog.css
+++ b/creativecloud/blocks/catalog/catalog.css
@@ -29,3 +29,12 @@
   order: 1;
   padding: 0;
 }
+
+.catalog.app .checkbox-group-id {
+  top: 0;
+  left: -2px;
+  width: 1px;
+  height: 1px;
+  position: absolute;
+  overflow: hidden;
+}

--- a/creativecloud/blocks/catalog/catalog.js
+++ b/creativecloud/blocks/catalog/catalog.js
@@ -65,6 +65,20 @@ export function enableAnalytics(catalog, merchCards, sidenav) {
   });
 }
 
+function addCheckboxGroupAttributes(sidenav) {
+  const cbGroup = sidenav.querySelector('merch-sidenav-checkbox-group');
+  if (!cbGroup) return;
+
+  const checkboxGroupId = 'sidenav-checkbox-group-title';
+  const h3El = cbGroup.shadowRoot.querySelector('h3');
+  h3El?.setAttribute('id', checkboxGroupId);
+
+  cbGroup.querySelectorAll('sp-checkbox').forEach((checkboxEl) => {
+    checkboxEl.setAttribute('role', 'group');
+    checkboxEl.setAttribute('aria-labelledby', checkboxGroupId);
+  });
+}
+
 /** container block */
 export default async function init(el) {
   el.classList.add('app');
@@ -85,6 +99,7 @@ export default async function init(el) {
       const sidenav = await initSidenav(sidenavEl);
       el.prepend(sidenav);
       await sidenav.updateComplete;
+      addCheckboxGroupAttributes(sidenav);
       if (merchCards) {
         merchCards.sidenav = sidenav;
         merchCards.requestUpdate();

--- a/creativecloud/blocks/catalog/catalog.js
+++ b/creativecloud/blocks/catalog/catalog.js
@@ -1,4 +1,4 @@
-import { getLibs } from '../../scripts/utils.js';
+import { getLibs, createTag } from '../../scripts/utils.js';
 
 const miloLibs = getLibs('/libs');
 const { loadStyle } = await import(`${miloLibs}/utils/utils.js`);
@@ -71,7 +71,11 @@ function addCheckboxGroupAttributes(sidenav) {
 
   const checkboxGroupId = 'sidenav-checkbox-group-title';
   const h3El = cbGroup.shadowRoot.querySelector('h3');
-  h3El?.setAttribute('id', checkboxGroupId);
+  if (!h3El) return;
+
+  const groupIdEl = createTag('div', { class: 'checkbox-group-id', id: checkboxGroupId });
+  groupIdEl.textContent = h3El.textContent;
+  cbGroup.append(groupIdEl);
 
   cbGroup.querySelectorAll('sp-checkbox').forEach((checkboxEl) => {
     checkboxEl.setAttribute('role', 'group');


### PR DESCRIPTION
… element - filter checkboxes

A11Y fix - For Type Desktop/Mobile/Web checkbox group ARIA group/labelledby technique applied to announce the grouping as a part of the checkboxes. This does not work if we have `aria-labelledby="elementId"` and `#elementId` is in shadow DOM so I had to create new hidden DIV, outside shadow DOM, which will have that ID and contain the test "Types".

Test page : /products/catalog

Resolves: [MWPW-162026](https://jira.corp.adobe.com/browse/MWPW-162026)

**Test URLs:**
- Before: https://main--cc--adobecom.hlx.live/?martech=off
- After: https://mwpw162026a11y--cc--bozojovicic.hlx.live/?martech=off
