### PR TITLE
Fix(Mwpw:164085): The icon beside 'Start over' is missing in interactive marquee.

### DIFF
--- a/creativecloud/features/interactive-components/start-over/start-over.js
+++ b/creativecloud/features/interactive-components/start-over/start-over.js
@@ -17,7 +17,7 @@ export default async function stepInit(data) {
   const config = data.stepConfigs[data.stepIndex];
   const layer = createTag('div', { class: `layer layer-${data.stepIndex}` });
   const startOverCTA = createTag('a', { class: 'gray-button start-over-button body-m next-step', href: '#' });
-  const svg = config.querySelector('picture img[src*=".svg"]:not(.accessibility-control)')?.closest('picture');
+  const svg = config.querySelector('picture img[src*=".svg"]:not(.accessibility-control)');
   if (svg) {
     svg.insertAdjacentElement('afterend', svg.cloneNode(true));
     startOverCTA.append(svg);

--- a/creativecloud/features/interactive-components/start-over/start-over.js
+++ b/creativecloud/features/interactive-components/start-over/start-over.js
@@ -17,7 +17,7 @@ export default async function stepInit(data) {
   const config = data.stepConfigs[data.stepIndex];
   const layer = createTag('div', { class: `layer layer-${data.stepIndex}` });
   const startOverCTA = createTag('a', { class: 'gray-button start-over-button body-m next-step', href: '#' });
-  const svg = config.querySelector('img[src*=".svg"]')?.closest('picture');
+  const svg = config.querySelector('img[src*=".svg"]:not(.accessibility-control)')?.closest('picture');
   if (svg) {
     svg.insertAdjacentElement('afterend', svg.cloneNode(true));
     startOverCTA.append(svg.closest('picture').cloneNode(true));

--- a/creativecloud/scripts/utils.js
+++ b/creativecloud/scripts/utils.js
@@ -154,6 +154,7 @@ const stageDomainsMap = {
     'creativecloud.adobe.com': 'stage.creativecloud.adobe.com',
     'projectneo.adobe.com': 'stg.projectneo.adobe.com',
   },
+  '.graybox.adobe.com': { 'www.adobe.com(?!\\/*\\S*\\/(mini-plans|plans-fragments\\/modals)\\/\\S*)': 'origin' },
 };
 
 /**


### PR DESCRIPTION
* The icon's used in accessibility controls were targeted while fetching the start-over icon, This behaviour is fixed in this PR.
Resolves: [MWPW-164085](https://jira.corp.adobe.com/browse/MWPW-164085)

**Test URLs:**
- Before: https://main--cc--adobecom.hlx.live/drafts/sharathkannan/accessiblity/startover?martech=off
- After: https://mwpw-164085--cc--sharath-kannan.hlx.live/drafts/sharathkannan/accessiblity/startover?martech=off
