### PR TITLE
MWPW-146930 - Rollout tool plugin

### DIFF
--- a/tools/sidekick/config.json
+++ b/tools/sidekick/config.json
@@ -153,6 +153,19 @@
       "title": "Bulk operations",
       "environments": [ "edit", "dev", "preview", "live" ],
       "url": "https://main--cc--adobecom.hlx.page/tools/bulk-publish"
+    },
+    
+    {
+      "containerId": "tools",
+      "id": "rollout",
+      "title": "Rollout",
+      "environments": [ "preview" ],
+      "isPalette": true,
+      "passReferrer": true,
+      "passConfig": true,
+      "url": "/tools/rollout",
+      "includePaths": [ "**.docx**", "**.xlsx**" ],
+      "paletteRect": "top: 40%; left: 50%; transform: translate(-50%,-50%); height: 350px; width: 500px; overflow: hidden; border-radius: 15px; box-shadow: 0 20px 35px 0px rgba(0, 0, 0, 0.5);"
     }
   ]
 }

--- a/tools/sidekick/config.json
+++ b/tools/sidekick/config.json
@@ -154,7 +154,6 @@
       "environments": [ "edit", "dev", "preview", "live" ],
       "url": "https://main--cc--adobecom.hlx.page/tools/bulk-publish"
     },
-    
     {
       "containerId": "tools",
       "id": "rollout",

--- a/tools/sidekick/config.json
+++ b/tools/sidekick/config.json
@@ -154,6 +154,7 @@
       "environments": [ "edit", "dev", "preview", "live" ],
       "url": "https://main--cc--adobecom.hlx.page/tools/bulk-publish"
     },
+    
     {
       "containerId": "tools",
       "id": "rollout",


### PR DESCRIPTION
Adding option in sidekick to rollout files directly to geos. This plugin will do some basic calculation and form a url. On selection of the environment, the user will be taken to the Loc V3 project config page with some options (sent as part of the parameter) pre-selected.

Resolves: https://jira.corp.adobe.com/browse/MWPW-146930

Test URLs:

- Before: https://main--cc--adobecom.hlx.page/?martech=off
- After: https://rollout-plugin--cc--sabyamon.hlx.page/?martech=off
This feature can be tested in CC by selecting the Test project configuration locally and providing the URL https://rollout-plugin--cc--sabyamon.hlx.page