### PR TITLE
[MWPW-166392] Zip/postal code validation pattern

### DIFF
--- a/creativecloud/features/cc-forms/components/textfield.js
+++ b/creativecloud/features/cc-forms/components/textfield.js
@@ -100,7 +100,7 @@ class Textfield {
         i.setAttribute('pattern', '^[0-9a-zA-Z\\-]*$');
         break;
       case 'postalcode':
-        i.setAttribute('pattern', '^[0-9a-zA-Z\\- ]*$');
+        i.setAttribute('pattern', '^(?=.*[0-9a-zA-Z])[0-9a-zA-Z\\- ]*$');
         break;
       case 'website':
         i.setAttribute('pattern', '^((ftp|http|https):\\/\\/)??(www\\.)?(?!.*(ftp|http|https|www\\.)).+[a-zA-Z0-9_\\-]+(\\.[a-zA-Z]+)+((\\/\\w*)*(\\/\\w+\\?[a-zA-Z0-9_]+=\\w+(&[a-zA-Z0-9_]+=\\w+)*)?)?\\/?$');

--- a/creativecloud/features/cc-forms/components/textfield.js
+++ b/creativecloud/features/cc-forms/components/textfield.js
@@ -100,7 +100,7 @@ class Textfield {
         i.setAttribute('pattern', '^[0-9a-zA-Z\\-]*$');
         break;
       case 'postalcode':
-        i.setAttribute('pattern', '^[0-9a-zA-Z\\-]*$');
+        i.setAttribute('pattern', '^[0-9a-zA-Z\\- ]*$');
         break;
       case 'website':
         i.setAttribute('pattern', '^((ftp|http|https):\\/\\/)??(www\\.)?(?!.*(ftp|http|https|www\\.)).+[a-zA-Z0-9_\\-]+(\\.[a-zA-Z]+)+((\\/\\w*)*(\\/\\w+\\?[a-zA-Z0-9_]+=\\w+(&[a-zA-Z0-9_]+=\\w+)*)?)?\\/?$');


### PR DESCRIPTION
* Fixes the zip/postal code validation pattern to include zipcodes with a space (eg. Canada, UK)

Resolves: [MWPW-166392](https://jira.corp.adobe.com/browse/MWPW-166392)

**Test URLs:**
- Before: https://main--cc--adobecom.hlx.live/drafts/mathuria/dalpforms/perpeptual?martech=off
- After: https://zipcode-fix--cc--adobecom.hlx.live/drafts/mathuria/dalpforms/perpeptual?martech=off
