### PR TITLE
Stop CMR creation in github workflow for

### DIFF
--- a/.github/workflows/servicenow.yaml
+++ b/.github/workflows/servicenow.yaml
@@ -6,9 +6,9 @@ name: Create CMR in ServiceNow
 on:
   pull_request:
     types:
-      - closed
+    #  - closed
     branches:
-      - main
+    #  - main
 
 permissions:
   contents: read

--- a/.github/workflows/servicenow.yaml
+++ b/.github/workflows/servicenow.yaml
@@ -4,11 +4,11 @@
 name: Create CMR in ServiceNow
 
 on:
-  pull_request:
-    types:
-    #  - closed
-    branches:
-    #  - main
+  #pull_request:
+  #  types:
+  #    - closed
+  #  branches:
+  #    - main
 
 permissions:
   contents: read

--- a/.github/workflows/servicenow.yaml
+++ b/.github/workflows/servicenow.yaml
@@ -4,7 +4,7 @@
 name: Create CMR in ServiceNow
 
 on:
-  #pull_request:
+  pull_request:
   #  types:
   #    - closed
   #  branches:


### PR DESCRIPTION
* Stopping the CMR creation workflow as there is some issue with service now api where Change ID is not returned after CMR creation. Aaron is working with Service Now team to get this resolved.
* Will enable this workflow once we get this resolved

### Test Urls
- Before: https://stage--cc--adobecom.aem.live/?martech=off
- After: https://cmr-workflow--cc--adobecom.aem.live/?martech=off
