### PR TITLE
MWPW-153103: creativecloud.adobe.com URLs not transforming during milo localization

### DIFF
--- a/creativecloud/scripts/utils.js
+++ b/creativecloud/scripts/utils.js
@@ -346,7 +346,7 @@ const CONFIG = {
   imsClientId: 'adobedotcom-cc',
   locales,
   geoRouting: 'on',
-  prodDomains: ['www.adobe.com', 'helpx.adobe.com', 'business.adobe.com'],
+  prodDomains: ['www.adobe.com', 'helpx.adobe.com', 'business.adobe.com', 'creativecloud.adobe.com'],
   stageDomainsMap,
   decorateArea,
   adobeid: {


### PR DESCRIPTION
* Added `creativecloud.adobe.com` prod domain in cc Config

Resolves: [MWPW-153103](https://jira.corp.adobe.com/browse/MWPW-153103)

**Test URLs:**
- Before: https://main--cc--adobecom.hlx.live/nz/drafts/siva/learn?martech=off
- After: https://mwpw-153103--cc--sivasadobe.hlx.live/nz/drafts/siva/learn?martech=off
