### PR TITLE
reverting the config file to support localization

### DIFF
--- a/tools/sidekick/config.json
+++ b/tools/sidekick/config.json
@@ -1,7 +1,5 @@
 {
   "project": "Creative Cloud",
-  "previewHost": "main--cc--adobecom.aem.page",
-  "liveHost": "main--cc--adobecom.aem.live",
   "plugins": [
     {
       "id": "path",
@@ -33,7 +31,7 @@
       "id": "localize",
       "title": "Localize",
       "environments": [ "edit" ],
-      "url": "https://main--milo--adobecom.aem.page/tools/loc/index.html?project=cc--adobecom",
+      "url": "https://main--milo--adobecom.hlx.page/tools/loc/index.html?project=cc--adobecom",
       "passReferrer": true,
       "includePaths": [ "**/:x**" ]
     },
@@ -42,7 +40,7 @@
       "id": "localize-2",
       "title": "Localize (V2)",
       "environments": [ "edit" ],
-      "url": "https://main--cc--adobecom.aem.page/tools/loc?milolibs=locui",
+      "url": "https://main--cc--adobecom.hlx.page/tools/loc?milolibs=locui",
       "passReferrer": true,
       "passConfig": true,
       "includePaths": [ "**.xlsx**" ]
@@ -52,7 +50,7 @@
       "id": "floodgate",
       "title": "Floodgate",
       "environments": [ "edit" ],
-      "url": "https://main--cc--adobecom.aem.page/tools/floodgate?milolibs=floodgateui",
+      "url": "https://main--cc--adobecom.hlx.page/tools/floodgate?milolibs=floodgateui",
       "passReferrer": true,
       "passConfig": true,
       "includePaths": [ "**/:x**" ]
@@ -154,7 +152,7 @@
       "id": "bulk",
       "title": "Bulk operations",
       "environments": [ "edit", "dev", "preview", "live" ],
-      "url": "https://main--cc--adobecom.aem.page/tools/bulk-publish"
+      "url": "https://main--cc--adobecom.hlx.page/tools/bulk-publish"
     },
     {
       "containerId": "tools",


### PR DESCRIPTION
Reverts the config file changes of #621

Before: https://main--cc--adobecom.hlx.live/products/photoshop?martech=off
After: https://hlx5-config-revert--cc--sharath-kannan.hlx.live/?martech=off
After-2: https://hlx5-config-revert--cc--sharath-kannan.hlx.live/products/photoshop?martech=off