### PR TITLE
Revert "reverting the config file to support localization"

### DIFF
--- a/tools/sidekick/config.json
+++ b/tools/sidekick/config.json
@@ -1,5 +1,7 @@
 {
   "project": "Creative Cloud",
+  "previewHost": "main--cc--adobecom.aem.page",
+  "liveHost": "main--cc--adobecom.aem.live",
   "plugins": [
     {
       "id": "path",
@@ -31,7 +33,7 @@
       "id": "localize",
       "title": "Localize",
       "environments": [ "edit" ],
-      "url": "https://main--milo--adobecom.hlx.page/tools/loc/index.html?project=cc--adobecom",
+      "url": "https://main--milo--adobecom.aem.page/tools/loc/index.html?project=cc--adobecom",
       "passReferrer": true,
       "includePaths": [ "**/:x**" ]
     },
@@ -40,7 +42,7 @@
       "id": "localize-2",
       "title": "Localize (V2)",
       "environments": [ "edit" ],
-      "url": "https://main--cc--adobecom.hlx.page/tools/loc?milolibs=locui",
+      "url": "https://main--cc--adobecom.aem.page/tools/loc?milolibs=locui",
       "passReferrer": true,
       "passConfig": true,
       "includePaths": [ "**.xlsx**" ]
@@ -50,7 +52,7 @@
       "id": "floodgate",
       "title": "Floodgate",
       "environments": [ "edit" ],
-      "url": "https://main--cc--adobecom.hlx.page/tools/floodgate?milolibs=floodgateui",
+      "url": "https://main--cc--adobecom.aem.page/tools/floodgate?milolibs=floodgateui",
       "passReferrer": true,
       "passConfig": true,
       "includePaths": [ "**/:x**" ]
@@ -152,7 +154,7 @@
       "id": "bulk",
       "title": "Bulk operations",
       "environments": [ "edit", "dev", "preview", "live" ],
-      "url": "https://main--cc--adobecom.hlx.page/tools/bulk-publish"
+      "url": "https://main--cc--adobecom.aem.page/tools/bulk-publish"
     },
     {
       "containerId": "tools",


### PR DESCRIPTION
Reverts https://github.com/adobecom/cc/pull/627
Test URLs:
Before: https://main--cc--adobecom.aem.live/?martech=off
After: https://revert-628-hlx5-config-revert--cc--adobecom.aem.live/?martech=off