### PR TITLE
Support both .aem. and .hlx. - HLX5 Support

### DIFF
--- a/.github/preview-index/README.md
+++ b/.github/preview-index/README.md
@@ -5,7 +5,7 @@ There are 2 scripts here, one for full reindex and one to reindex a single docum
 The script for full reindex:
 * query all 'previewed' resources in folder /cc-shared/fragments/merch/*
 * filter out .json or urls that don't contain /merch-card/ in the path
-* for each merch-card resource, it will request .hlx.page content 
+* for each merch-card resource, it will request .aem.page content 
 * parse the content to the index table row, similar to the 'merch-cards' index definition in 'helix-query.yaml'
 * delete all rows from /cc-shared/assets/query-index-cards-preview.xslx, 'raw_index' sheet, 'Table1'
 * add new generated rows to the index
@@ -26,7 +26,7 @@ If you do a change to .env file, remember to re-run 'npm i' before running 'npm 
 The script for reindexing of a single document
 * is triggered on 'resource-previewed' event
 * will work only if resource path contains /merch-card/ and does not end with .json
-* for the resource path it requests .hlx.page content
+* for the resource path it requests .aem.page content
 * it searches for the existing row in /cc-shared/assets/query-index-cards-preview.xslx for this resource 
 * if it exists, it updates that row with new details
 * otherwise it inserts new row
@@ -55,7 +55,7 @@ ENABLED=y
 
 `SHAREPOINT_CLIENT_ID` and `SHAREPOINT_TENANT_ID` can be found on the azure app 'Essential' tab, see 'Application (client) ID' and 'Directory (tenant) ID'.
 `PREVIEW_INDEX_FILE` path to the target index file, e.g. "milo/drafts/mariia/preview-index/query-index-cards-preview.xlsx"
-`PREVIEW_RESOURCES_FOLDER` path to resource to index, e.g. "/drafts/mariia/preview-index/*". Folder path is not sharepoint path, but mapped *hlx.page location. So if your sharepoint folder is CC/www/cc-shared/myfolder, please specify /cc-shared/myfolder.
+`PREVIEW_RESOURCES_FOLDER` path to resource to index, e.g. "/drafts/mariia/preview-index/*". Folder path is not sharepoint path, but mapped *aem.page location. So if your sharepoint folder is CC/www/cc-shared/myfolder, please specify /cc-shared/myfolder.
 `PREVIEW_LOCALES` comma separated string of locales supported appart from us e.g. ca,at_de,au
 
 Azure app: [CC preview index](https://portal.azure.com/#view/Microsoft_AAD_RegisteredApps/ApplicationMenuBlade/~/Overview/appId/94136756-61af-4f63-af05-6991a719b872/isMSAApp~/false)
@@ -75,7 +75,7 @@ curl -v -X POST --header "Authorization: token admin_token" -H "Content-Type: ap
 ## EDS Get page content
 Admin token and access token are different values!
 ```
-curl -v --header "Authorization: token access_token" -H "Content-Type: application/json" 'https://main--cc--adobecom.hlx.page/cc-shared/fragments/merch/products/catalog/merch-card/ec/target/default'
+curl -v --header "Authorization: token access_token" -H "Content-Type: application/json" 'https://main--cc--adobecom.aem.page/cc-shared/fragments/merch/products/catalog/merch-card/ec/target/default'
 ```
 
 ## GRAPH API: Get index file Item ID

--- a/.github/preview-index/src/indexFull.js
+++ b/.github/preview-index/src/indexFull.js
@@ -24,8 +24,8 @@ const config = getConfig();
  * Fetch all previewed resources in specified folder. Bulk status job is asynchronyous, 
  * so the method will keep re-fetching the status till the job is done. Interval - 5 seconds.
  * When Bulk Status returned all previewed resource paths, map each path to a function that will 
- * request this path content from hlx.page and map it to index row.
- * Concurrent Requests to hlx.page are limited to 20 in order not to overload EDS. hlx.page is an uncached endpoint.
+ * request this path content from aem.page and map it to index row.
+ * Concurrent Requests to aem.page are limited to 20 in order not to overload EDS. aem.page is an uncached endpoint.
  * Promise.allSettled instead of Promise.all insures the script will execute for rest of paths, even if one of them failed.
  * @param {*} folder 
  * @param {*} parseIndexFc 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,5 +3,5 @@
 Resolves: [MWPW-NUMBER](https://jira.corp.adobe.com/browse/MWPW-NUMBER)
 
 **Test URLs:**
-- Before: https://main--cc--adobecom.hlx.live/?martech=off
-- After: https://<branch>--cc--adobecom.hlx.live/?martech=off
+- Before: https://main--cc--adobecom.aem.live/?martech=off
+- After: https://<branch>--cc--adobecom.aem.live/?martech=off

--- a/.github/workflows/merge-to-stage.js
+++ b/.github/workflows/merge-to-stage.js
@@ -5,8 +5,8 @@ const SEEN = {};
 let github, owner, repo;
 let body = `
 **Creative cloud:**
-- Before: https://${PROD}--cc--adobecom.hlx.live/?martech=off
-- After: https://${STAGE}--cc--adobecom.hlx.live/?martech=off
+- Before: https://${PROD}--cc--adobecom.aem.live/?martech=off
+- After: https://${STAGE}--cc--adobecom.aem.live/?martech=off
 `;
 const REQUIRED_APPROVALS = process.env.REQUIRED_APPROVALS || 2;
 const LABELS = {

--- a/creativecloud/blocks/unity/unity.js
+++ b/creativecloud/blocks/unity/unity.js
@@ -25,12 +25,15 @@ function getUnityLibs(prodLibs = '/unitylibs') {
   const { hostname } = window.location;
   if (!hostname.includes('hlx.page')
     && !hostname.includes('hlx.live')
+    && !hostname.includes('aem.page')
+    && !hostname.includes('aem.live')
     && !hostname.includes('localhost')) {
     return prodLibs;
   }
   const branch = new URLSearchParams(window.location.search).get('unitylibs') || 'main';
-  if (branch.indexOf('--') > -1) return `https://${branch}.hlx.live/unitylibs`;
-  return `https://${branch}--unity--adobecom.hlx.live/unitylibs`;
+  const env = hostname.includes('.hlx.') ? 'hlx' : 'aem';
+  if (branch.indexOf('--') > -1) return `https://${branch}.${env}.live/unitylibs`;
+  return `https://${branch}--unity--adobecom.${env}.live/unitylibs`;
 }
 
 export default async function init(el) {

--- a/creativecloud/features/changeBg/changeBg.js
+++ b/creativecloud/features/changeBg/changeBg.js
@@ -54,7 +54,7 @@ function createGroups(vp, current, swatchArr, srcArr) {
 
 export default async function changeBg(el) {
   const { host } = window.location;
-  if (host.includes('hlx.page')) {
+  if (host.includes('hlx.page') || host.includes('aem.page')) {
     const { default: debug } = await import('./author-feedback.js');
     debug(el);
   }

--- a/creativecloud/scripts/utils.js
+++ b/creativecloud/scripts/utils.js
@@ -132,7 +132,7 @@ const stageDomainsMap = {
     'creativecloud.adobe.com': 'stage.creativecloud.adobe.com',
     'projectneo.adobe.com': 'stg.projectneo.adobe.com',
   },
-  '--cc--adobecom.hlx.live': {
+  '--cc--adobecom.(hlx|aem).live': {
     'www.adobe.com(?!\\/*\\S*\\/(mini-plans|plans-fragments\\/modals)\\/\\S*)': 'origin',
     'business.adobe.com': 'business.stage.adobe.com',
     'helpx.adobe.com': 'helpx.stage.adobe.com',
@@ -143,7 +143,7 @@ const stageDomainsMap = {
     'creativecloud.adobe.com': 'stage.creativecloud.adobe.com',
     'projectneo.adobe.com': 'stg.projectneo.adobe.com',
   },
-  '--cc--adobecom.hlx.page': {
+  '--cc--adobecom.(hlx|aem).page': {
     'www.adobe.com(?!\\/*\\S*\\/(mini-plans|plans-fragments\\/modals)\\/\\S*)': 'origin',
     'business.adobe.com': 'business.stage.adobe.com',
     'helpx.adobe.com': 'helpx.stage.adobe.com',
@@ -171,14 +171,17 @@ export const [setLibs, getLibs] = (() => {
       const { hostname } = window.location;
       if (!hostname.includes('hlx.page')
         && !hostname.includes('hlx.live')
+        && !hostname.includes('aem.page')
+        && !hostname.includes('aem.live')
         && !hostname.includes('localhost')) {
         libs = prodLibs;
         return libs;
       }
       const branch = new URLSearchParams(window.location.search).get('milolibs') || 'main';
       if (branch === 'local') { libs = 'http://localhost:6456/libs'; return libs; }
-      if (branch.indexOf('--') > -1) { libs = `https://${branch}.hlx.live/libs`; return libs; }
-      libs = `https://${branch}--milo--adobecom.hlx.live/libs`;
+      const env = hostname.includes('.hlx.') ? 'hlx' : 'aem';
+      if (branch.indexOf('--') > -1) { libs = `https://${branch}.${env}.live/libs`; return libs; }
+      libs = `https://${branch}--milo--adobecom.${env}.live/libs`;
       return libs;
     }, () => libs,
   ];

--- a/libs/deps/README
+++ b/libs/deps/README
@@ -1,1 +1,1 @@
-this is only for loading lit only once on hlx.page and hlx.live
+this is only for loading lit only once on aem.page and aem.live

--- a/test/blocks/interactive-metadata/mocks/interactive-metadata.html
+++ b/test/blocks/interactive-metadata/mocks/interactive-metadata.html
@@ -49,13 +49,13 @@
     <div>
       <div>
         <p><a
-            href="/drafts/mathuria/interactiveelems/demo/northernlights/assets/moon1-video.mp4#_autoplay">https://main--cc--adobecom.hlx.page/drafts/mathuria/interactiveelems/demo/northernlights/assets/moon1-video.mp4#_autoplay</a>
+            href="/drafts/mathuria/interactiveelems/demo/northernlights/assets/moon1-video.mp4#_autoplay">https://main--cc--adobecom.aem.page/drafts/mathuria/interactiveelems/demo/northernlights/assets/moon1-video.mp4#_autoplay</a>
         </p>
         <p><a
-            href="/drafts/mathuria/interactiveelems/demo/northernlights/assets/moon2-video.mp4#_autoplay">https://main--cc--adobecom.hlx.page/drafts/mathuria/interactiveelems/demo/northernlights/assets/moon2-video.mp4#_autoplay</a>
+            href="/drafts/mathuria/interactiveelems/demo/northernlights/assets/moon2-video.mp4#_autoplay">https://main--cc--adobecom.aem.page/drafts/mathuria/interactiveelems/demo/northernlights/assets/moon2-video.mp4#_autoplay</a>
         </p>
         <p><a
-            href="/drafts/mathuria/interactiveelems/demo/northernlights/assets/moon3-video.mp4#_autoplay">https://main--cc--adobecom.hlx.page/drafts/mathuria/interactiveelems/demo/northernlights/assets/moon3-video.mp4</a>
+            href="/drafts/mathuria/interactiveelems/demo/northernlights/assets/moon3-video.mp4#_autoplay">https://main--cc--adobecom.aem.page/drafts/mathuria/interactiveelems/demo/northernlights/assets/moon3-video.mp4</a>
         </p>
         <p>
           <picture><img loading="lazy" src="./test/blocks/interactive-metadata/mocks/assets/icon_.svg"></picture>

--- a/test/features/firefly/mocks/body.html
+++ b/test/features/firefly/mocks/body.html
@@ -11,33 +11,33 @@
         <p><strong><a href="https://firefly.adobe.com/">Get Firefly Free</a></strong></p>
       </div>
       <div data-valign="middle">
-        <p><a href="https://main--cc--adobecom.hlx.page/drafts/ruchika/svg/enticement-arrow.svg">Try it</a></p>
+        <p><a href="https://main--cc--adobecom.aem.page/drafts/ruchika/svg/enticement-arrow.svg">Try it</a></p>
         <p><strong>-----------------------------------------------------------</strong></p>
-        <p><a href=https://firefly.adobe.com/generate/images#_dnt>https://firefly.adobe.com/generate/images#_dnt</a> <a href="https://main--cc--adobecom.hlx.page/drafts/ruchika/svg/text-to-image.svg">Text to Image</a></p>
+        <p><a href=https://firefly.adobe.com/generate/images#_dnt>https://firefly.adobe.com/generate/images#_dnt</a> <a href="https://main--cc--adobecom.aem.page/drafts/ruchika/svg/text-to-image.svg">Text to Image</a></p>
         <p>Dog in a sweater, primary colors, big smile|Generate</p>
         <p>
           <picture>
-            <source type="image/webp" srcset="https://main--cc--adobecom.hlx.page/creativecloud/media_19f56591bac629c3d4d0e4023588de86f4a0142f2.jpeg?width=2000&#x26;format=webply&#x26;optimize=medium" media="(min-width: 600px)">
-            <source type="image/webp" srcset="https://main--cc--adobecom.hlx.page/creativecloud/media_19f56591bac629c3d4d0e4023588de86f4a0142f2.jpeg?width=750&#x26;format=webply&#x26;optimize=medium">
-            <source type="image/jpeg" srcset="https://main--cc--adobecom.hlx.page/creativecloud/media_19f56591bac629c3d4d0e4023588de86f4a0142f2.jpeg?width=2000&#x26;format=jpeg&#x26;optimize=medium" media="(min-width: 600px)">
-            <img loading="lazy" alt="" src="https://main--cc--adobecom.hlx.page/creativecloud/media_19f56591bac629c3d4d0e4023588de86f4a0142f2.jpeg?width=750&#x26;format=jpeg&#x26;optimize=medium" width="1000" height="1000">
+            <source type="image/webp" srcset="https://main--cc--adobecom.aem.page/creativecloud/media_19f56591bac629c3d4d0e4023588de86f4a0142f2.jpeg?width=2000&#x26;format=webply&#x26;optimize=medium" media="(min-width: 600px)">
+            <source type="image/webp" srcset="https://main--cc--adobecom.aem.page/creativecloud/media_19f56591bac629c3d4d0e4023588de86f4a0142f2.jpeg?width=750&#x26;format=webply&#x26;optimize=medium">
+            <source type="image/jpeg" srcset="https://main--cc--adobecom.aem.page/creativecloud/media_19f56591bac629c3d4d0e4023588de86f4a0142f2.jpeg?width=2000&#x26;format=jpeg&#x26;optimize=medium" media="(min-width: 600px)">
+            <img loading="lazy" alt="" src="https://main--cc--adobecom.aem.page/creativecloud/media_19f56591bac629c3d4d0e4023588de86f4a0142f2.jpeg?width=750&#x26;format=jpeg&#x26;optimize=medium" width="1000" height="1000">
           </picture>
         </p>
         <p><strong>-----------------------------------------------------------</strong></p>
-        <p><a href=https://firefly.adobe.com/upload/inpaint#_dnt>https://firefly.adobe.com/upload/inpaint#_dnt</a><a href="https://main--cc--adobecom.hlx.page/drafts/ruchika/svg/genfill.svg">Generative Fill</a></p>
+        <p><a href=https://firefly.adobe.com/upload/inpaint#_dnt>https://firefly.adobe.com/upload/inpaint#_dnt</a><a href="https://main--cc--adobecom.aem.page/drafts/ruchika/svg/genfill.svg">Generative Fill</a></p>
         <p>Prompt Used[Turquoise water reflecting a starry sky]|Try Generative Fill</p>
         <p><video playsinline="" autoplay="" loop="" muted="">
-          <source src="https://main--cc--adobecom.hlx.page/creativecloud/media_18d4118fdf2a27f38f25d20dc1a6518d4587bb7e5.mp4" type="video/mp4">
+          <source src="https://main--cc--adobecom.aem.page/creativecloud/media_18d4118fdf2a27f38f25d20dc1a6518d4587bb7e5.mp4" type="video/mp4">
         </video></p>
         <p><strong>-----------------------------------------------------------</strong></p>
-        <p><a href=https://firefly.adobe.com/generate/font-styles#_dnt>https://firefly.adobe.com/generate/font-styles#_dnt</a>|<a href="https://main--cc--adobecom.hlx.page/drafts/ruchika/svg/text-effects.svg">Text Effects</a></p>
+        <p><a href=https://firefly.adobe.com/generate/font-styles#_dnt>https://firefly.adobe.com/generate/font-styles#_dnt</a>|<a href="https://main--cc--adobecom.aem.page/drafts/ruchika/svg/text-effects.svg">Text Effects</a></p>
         <p>Tiger Fur|Generate</p>
         <p>
           <picture>
-            <source type="image/webp" srcset="https://main--cc--adobecom.hlx.page/creativecloud/media_1b4ccb77566c559be9f32aa4b12527bc34e3d5b3f.jpeg?width=2000&#x26;format=webply&#x26;optimize=medium" media="(min-width: 600px)">
-            <source type="image/webp" srcset="https://main--cc--adobecom.hlx.page/creativecloud/media_1b4ccb77566c559be9f32aa4b12527bc34e3d5b3f.jpeg?width=750&#x26;format=webply&#x26;optimize=medium">
-            <source type="image/jpeg" srcset="https://main--cc--adobecom.hlx.page/creativecloud/media_1b4ccb77566c559be9f32aa4b12527bc34e3d5b3f.jpeg?width=2000&#x26;format=jpeg&#x26;optimize=medium" media="(min-width: 600px)">
-            <img loading="lazy" alt="" src="https://main--cc--adobecom.hlx.page/creativecloud/media_1b4ccb77566c559be9f32aa4b12527bc34e3d5b3f.jpeg?width=750&#x26;format=jpeg&#x26;optimize=medium" width="1024" height="1024">
+            <source type="image/webp" srcset="https://main--cc--adobecom.aem.page/creativecloud/media_1b4ccb77566c559be9f32aa4b12527bc34e3d5b3f.jpeg?width=2000&#x26;format=webply&#x26;optimize=medium" media="(min-width: 600px)">
+            <source type="image/webp" srcset="https://main--cc--adobecom.aem.page/creativecloud/media_1b4ccb77566c559be9f32aa4b12527bc34e3d5b3f.jpeg?width=750&#x26;format=webply&#x26;optimize=medium">
+            <source type="image/jpeg" srcset="https://main--cc--adobecom.aem.page/creativecloud/media_1b4ccb77566c559be9f32aa4b12527bc34e3d5b3f.jpeg?width=2000&#x26;format=jpeg&#x26;optimize=medium" media="(min-width: 600px)">
+            <img loading="lazy" alt="" src="https://main--cc--adobecom.aem.page/creativecloud/media_1b4ccb77566c559be9f32aa4b12527bc34e3d5b3f.jpeg?width=750&#x26;format=jpeg&#x26;optimize=medium" width="1024" height="1024">
           </picture>
         </p>
       </div>
@@ -64,21 +64,21 @@
       <p><strong><a href="https://firefly.adobe.com/">Get Firefly Free</a></strong></p>
     </div>
     <div data-valign="middle">
-      <p><a href="https://main--cc--adobecom.hlx.page/drafts/ruchika/svg/enticement-arrow.svg">Try it</a></p>
+      <p><a href="https://main--cc--adobecom.aem.page/drafts/ruchika/svg/enticement-arrow.svg">Try it</a></p>
       <p><strong>-----------------------------------------------------------</strong></p>
       <p>Tiger Fur|Generate</p>
       <p>
         <picture>
           <source type="image/webp"
-              srcset="https://main--cc--adobecom.hlx.page/creativecloud/media_1b4ccb77566c559be9f32aa4b12527bc34e3d5b3f.jpeg?width=2000&#x26;format=webply&#x26;optimize=medium"
+              srcset="https://main--cc--adobecom.aem.page/creativecloud/media_1b4ccb77566c559be9f32aa4b12527bc34e3d5b3f.jpeg?width=2000&#x26;format=webply&#x26;optimize=medium"
               media="(min-width: 600px)">
           <source type="image/webp"
-              srcset="https://main--cc--adobecom.hlx.page/creativecloud/media_1b4ccb77566c559be9f32aa4b12527bc34e3d5b3f.jpeg?width=750&#x26;format=webply&#x26;optimize=medium">
+              srcset="https://main--cc--adobecom.aem.page/creativecloud/media_1b4ccb77566c559be9f32aa4b12527bc34e3d5b3f.jpeg?width=750&#x26;format=webply&#x26;optimize=medium">
           <source type="image/jpeg"
-              srcset="https://main--cc--adobecom.hlx.page/creativecloud/media_1b4ccb77566c559be9f32aa4b12527bc34e3d5b3f.jpeg?width=2000&#x26;format=jpeg&#x26;optimize=medium"
+              srcset="https://main--cc--adobecom.aem.page/creativecloud/media_1b4ccb77566c559be9f32aa4b12527bc34e3d5b3f.jpeg?width=2000&#x26;format=jpeg&#x26;optimize=medium"
               media="(min-width: 600px)">
           <img loading="lazy" alt=""
-              src="https://main--cc--adobecom.hlx.page/creativecloud/media_1b4ccb77566c559be9f32aa4b12527bc34e3d5b3f.jpeg?width=750&#x26;format=jpeg&#x26;optimize=medium"
+              src="https://main--cc--adobecom.aem.page/creativecloud/media_1b4ccb77566c559be9f32aa4b12527bc34e3d5b3f.jpeg?width=750&#x26;format=jpeg&#x26;optimize=medium"
               width="1024" height="1024">
         </picture>
       </p>
@@ -105,21 +105,21 @@
       <p><strong><a href="https://firefly.adobe.com/">Get Firefly Free</a></strong></p>
     </div>
     <div data-valign="middle">
-      <p><a href="https://main--cc--adobecom.hlx.page/drafts/ruchika/svg/enticement-arrow.svg">Try it</a></p>
+      <p><a href="https://main--cc--adobecom.aem.page/drafts/ruchika/svg/enticement-arrow.svg">Try it</a></p>
       <p><strong>-----------------------------------------------------------</strong></p>
       <p>Tiger Fur|Generate</p>
       <p>
         <picture>
           <source type="image/webp"
-              srcset="https://main--cc--adobecom.hlx.page/creativecloud/media_1b4ccb77566c559be9f32aa4b12527bc34e3d5b3f.jpeg?width=2000&#x26;format=webply&#x26;optimize=medium"
+              srcset="https://main--cc--adobecom.aem.page/creativecloud/media_1b4ccb77566c559be9f32aa4b12527bc34e3d5b3f.jpeg?width=2000&#x26;format=webply&#x26;optimize=medium"
               media="(min-width: 600px)">
           <source type="image/webp"
-              srcset="https://main--cc--adobecom.hlx.page/creativecloud/media_1b4ccb77566c559be9f32aa4b12527bc34e3d5b3f.jpeg?width=750&#x26;format=webply&#x26;optimize=medium">
+              srcset="https://main--cc--adobecom.aem.page/creativecloud/media_1b4ccb77566c559be9f32aa4b12527bc34e3d5b3f.jpeg?width=750&#x26;format=webply&#x26;optimize=medium">
           <source type="image/jpeg"
-              srcset="https://main--cc--adobecom.hlx.page/creativecloud/media_1b4ccb77566c559be9f32aa4b12527bc34e3d5b3f.jpeg?width=2000&#x26;format=jpeg&#x26;optimize=medium"
+              srcset="https://main--cc--adobecom.aem.page/creativecloud/media_1b4ccb77566c559be9f32aa4b12527bc34e3d5b3f.jpeg?width=2000&#x26;format=jpeg&#x26;optimize=medium"
               media="(min-width: 600px)">
           <img loading="lazy" alt=""
-              src="https://main--cc--adobecom.hlx.page/creativecloud/media_1b4ccb77566c559be9f32aa4b12527bc34e3d5b3f.jpeg?width=750&#x26;format=jpeg&#x26;optimize=medium"
+              src="https://main--cc--adobecom.aem.page/creativecloud/media_1b4ccb77566c559be9f32aa4b12527bc34e3d5b3f.jpeg?width=750&#x26;format=jpeg&#x26;optimize=medium"
               width="1024" height="1024">
         </picture>
       </p>
@@ -139,33 +139,33 @@
         <p><strong><a href="https://firefly.adobe.com/">Get Firefly Free</a></strong></p>
       </div>
       <div data-valign="middle">
-        <p><a href="https://main--cc--adobecom.hlx.page/drafts/ruchika/svg/enticement-arrow.svg">Try it</a></p>
+        <p><a href="https://main--cc--adobecom.aem.page/drafts/ruchika/svg/enticement-arrow.svg">Try it</a></p>
         <p><strong>-----------------------------------------------------------</strong></p>
-        <p><a href=https://firefly.adobe.com/upload/inpaint#_dnt>https://firefly.adobe.com/upload/inpaint#_dnt</a><a href="https://main--cc--adobecom.hlx.page/drafts/ruchika/svg/genfill.svg">Generative Fill</a></p>
+        <p><a href=https://firefly.adobe.com/upload/inpaint#_dnt>https://firefly.adobe.com/upload/inpaint#_dnt</a><a href="https://main--cc--adobecom.aem.page/drafts/ruchika/svg/genfill.svg">Generative Fill</a></p>
         <p>Prompt Used[Turquoise water reflecting a starry sky]|Try Generative Fill</p>
         <p><video playsinline="" autoplay="" loop="" muted="">
-          <source src="https://main--cc--adobecom.hlx.page/creativecloud/media_18d4118fdf2a27f38f25d20dc1a6518d4587bb7e5.mp4" type="video/mp4">
+          <source src="https://main--cc--adobecom.aem.page/creativecloud/media_18d4118fdf2a27f38f25d20dc1a6518d4587bb7e5.mp4" type="video/mp4">
         </video></p>
         <p><strong>-----------------------------------------------------------</strong></p>
-        <p><a href=https://firefly.adobe.com/generate/images#_dnt>https://firefly.adobe.com/generate/images#_dnt</a> <a href="https://main--cc--adobecom.hlx.page/drafts/ruchika/svg/text-to-image.svg">Text to Image</a></p>
+        <p><a href=https://firefly.adobe.com/generate/images#_dnt>https://firefly.adobe.com/generate/images#_dnt</a> <a href="https://main--cc--adobecom.aem.page/drafts/ruchika/svg/text-to-image.svg">Text to Image</a></p>
         <p>Dog in a sweater, primary colors, big smile|Generate</p>
         <p>
           <picture>
-            <source type="image/webp" srcset="https://main--cc--adobecom.hlx.page/creativecloud/media_19f56591bac629c3d4d0e4023588de86f4a0142f2.jpeg?width=2000&#x26;format=webply&#x26;optimize=medium" media="(min-width: 600px)">
-            <source type="image/webp" srcset="https://main--cc--adobecom.hlx.page/creativecloud/media_19f56591bac629c3d4d0e4023588de86f4a0142f2.jpeg?width=750&#x26;format=webply&#x26;optimize=medium">
-            <source type="image/jpeg" srcset="https://main--cc--adobecom.hlx.page/creativecloud/media_19f56591bac629c3d4d0e4023588de86f4a0142f2.jpeg?width=2000&#x26;format=jpeg&#x26;optimize=medium" media="(min-width: 600px)">
-            <img loading="lazy" alt="" src="https://main--cc--adobecom.hlx.page/creativecloud/media_19f56591bac629c3d4d0e4023588de86f4a0142f2.jpeg?width=750&#x26;format=jpeg&#x26;optimize=medium" width="1000" height="1000">
+            <source type="image/webp" srcset="https://main--cc--adobecom.aem.page/creativecloud/media_19f56591bac629c3d4d0e4023588de86f4a0142f2.jpeg?width=2000&#x26;format=webply&#x26;optimize=medium" media="(min-width: 600px)">
+            <source type="image/webp" srcset="https://main--cc--adobecom.aem.page/creativecloud/media_19f56591bac629c3d4d0e4023588de86f4a0142f2.jpeg?width=750&#x26;format=webply&#x26;optimize=medium">
+            <source type="image/jpeg" srcset="https://main--cc--adobecom.aem.page/creativecloud/media_19f56591bac629c3d4d0e4023588de86f4a0142f2.jpeg?width=2000&#x26;format=jpeg&#x26;optimize=medium" media="(min-width: 600px)">
+            <img loading="lazy" alt="" src="https://main--cc--adobecom.aem.page/creativecloud/media_19f56591bac629c3d4d0e4023588de86f4a0142f2.jpeg?width=750&#x26;format=jpeg&#x26;optimize=medium" width="1000" height="1000">
           </picture>
         </p>
         <p><strong>-----------------------------------------------------------</strong></p>
-        <p><a href=https://firefly.adobe.com/generate/font-styles#_dnt>https://firefly.adobe.com/generate/font-styles#_dnt</a>|<a href="https://main--cc--adobecom.hlx.page/drafts/ruchika/svg/text-effects.svg">Text Effects</a></p>
+        <p><a href=https://firefly.adobe.com/generate/font-styles#_dnt>https://firefly.adobe.com/generate/font-styles#_dnt</a>|<a href="https://main--cc--adobecom.aem.page/drafts/ruchika/svg/text-effects.svg">Text Effects</a></p>
         <p>Tiger Fur|Generate</p>
         <p>
           <picture>
-            <source type="image/webp" srcset="https://main--cc--adobecom.hlx.page/creativecloud/media_1b4ccb77566c559be9f32aa4b12527bc34e3d5b3f.jpeg?width=2000&#x26;format=webply&#x26;optimize=medium" media="(min-width: 600px)">
-            <source type="image/webp" srcset="https://main--cc--adobecom.hlx.page/creativecloud/media_1b4ccb77566c559be9f32aa4b12527bc34e3d5b3f.jpeg?width=750&#x26;format=webply&#x26;optimize=medium">
-            <source type="image/jpeg" srcset="https://main--cc--adobecom.hlx.page/creativecloud/media_1b4ccb77566c559be9f32aa4b12527bc34e3d5b3f.jpeg?width=2000&#x26;format=jpeg&#x26;optimize=medium" media="(min-width: 600px)">
-            <img loading="lazy" alt="" src="https://main--cc--adobecom.hlx.page/creativecloud/media_1b4ccb77566c559be9f32aa4b12527bc34e3d5b3f.jpeg?width=750&#x26;format=jpeg&#x26;optimize=medium" width="1024" height="1024">
+            <source type="image/webp" srcset="https://main--cc--adobecom.aem.page/creativecloud/media_1b4ccb77566c559be9f32aa4b12527bc34e3d5b3f.jpeg?width=2000&#x26;format=webply&#x26;optimize=medium" media="(min-width: 600px)">
+            <source type="image/webp" srcset="https://main--cc--adobecom.aem.page/creativecloud/media_1b4ccb77566c559be9f32aa4b12527bc34e3d5b3f.jpeg?width=750&#x26;format=webply&#x26;optimize=medium">
+            <source type="image/jpeg" srcset="https://main--cc--adobecom.aem.page/creativecloud/media_1b4ccb77566c559be9f32aa4b12527bc34e3d5b3f.jpeg?width=2000&#x26;format=jpeg&#x26;optimize=medium" media="(min-width: 600px)">
+            <img loading="lazy" alt="" src="https://main--cc--adobecom.aem.page/creativecloud/media_1b4ccb77566c559be9f32aa4b12527bc34e3d5b3f.jpeg?width=750&#x26;format=jpeg&#x26;optimize=medium" width="1024" height="1024">
           </picture>
         </p>
       </div>

--- a/test/features/firefly/mocks/masonry-body.html
+++ b/test/features/firefly/mocks/masonry-body.html
@@ -10,9 +10,9 @@
         <p><strong><a href="https://firefly.adobe.com/">Get Firefly Free</a></strong></p>
       </div>
       <div data-valign="middle">
-        <p><a href="https://main--cc--adobecom.hlx.page/drafts/ruchika/svg/enticement-arrow-light.svg">Try it</a></p>
+        <p><a href="https://main--cc--adobecom.aem.page/drafts/ruchika/svg/enticement-arrow-light.svg">Try it</a></p>
         <p>Prompt Used</p>
-        <p><a href="https://main--cc--adobecom.hlx.page/drafts/ruchika/svg/smock-openin-18-n.svg">Launch in Firefly</a></p>
+        <p><a href="https://main--cc--adobecom.aem.page/drafts/ruchika/svg/smock-openin-18-n.svg">Launch in Firefly</a></p>
         <p>-----------------------------------------------------------</p>
         <p>Describe the image you want to create|<a href="https://firefly.adobe.com/shared/texttoimage?id=urn:aaid:sc:US:98293843-589b-4e19-abe9-e7eab412769b&#x26;ff_channel=adobe_com&#x26;ff_campaign=ffly_homepage&#x26;ff_source=firefly_seo">Generate</a></p>
         <p>

--- a/web-test-runner.config.mjs
+++ b/web-test-runner.config.mjs
@@ -32,7 +32,7 @@ const swcImportMaps = Object.fromEntries([
   'icons/cross.js',
 ].map((file) => [`/libs/features/spectrum-web-components/dist/${file}`, `/node_modules/@adobecom/milo/libs/features/spectrum-web-components/dist/${file}`]));
 
-const miloImportMaps = { 'libs/': 'https://main--milo--adobecom.hlx.live/libs/' };
+const miloImportMaps = { 'libs/': 'https://main--milo--adobecom.aem.live/libs/' };
 
 export default {
   coverageConfig: {


### PR DESCRIPTION
### Description 
Upgrading to aem.live from hlx.live as per the product requirements and [docs](https://www.aem.live/developer/upgrade).
This is not meant to be a complete PR but a spike to ensure you have everything you need and should be carefully QA'd

### Todo's
1. This will need proper QA
2. This will need to get merged
3. This will need an origin swap on the akamai level to consume `aem.page` and `aem.live` 
4. Once we switched the origin, we can delete references to `hlx.live` or `hlx.page`


### Test URLs
All 4 variations should work: `hlx.page` `aem.page` `hlx.live` `aem.live`

Before: https://main--cc--adobecom.aem.live/products/photoshop?martech=off&georouting=off
After: https://revert-620-revert-484-hlx-5--cc--adobecom.hlx.live/products/photoshop?martech=off&georouting=off
After-2: https://revert-620-revert-484-hlx-5--cc--adobecom.aem.live/products/photoshop?martech=off&georouting=off

### Known issues
- Sidekick err: https://github.com/adobecom/milo/pull/3349
- geo2 CORS issues https://jira.corp.adobe.com/browse/MWPW-161999
