### PR TITLE
MWPW-165929 | Error message and dropdown values rendered is not seen retained in device , shown as flash and disappear

### DIFF
--- a/creativecloud/features/cc-forms/components/checkbox.js
+++ b/creativecloud/features/cc-forms/components/checkbox.js
@@ -109,6 +109,10 @@ class Checkbox {
       const elem = this.checkboxInput.closest('.form-item').querySelector(`${SELECTOR_PREFIX_MESSAGE}required`);
       if (!elem) return this.valid;
       if (showError) {
+        this.checkboxInput.scrollIntoView({
+          behavior: 'smooth',
+          block: 'center',
+        });
         this.checkboxInput.setCustomValidity(`${elem.innerText}`);
         this.checkboxInput.reportValidity();
         this.form.setAttribute('data-show-error', 'false');

--- a/creativecloud/features/cc-forms/components/dropdown.js
+++ b/creativecloud/features/cc-forms/components/dropdown.js
@@ -240,6 +240,10 @@ class Dropdown {
     const elem = this.dropdown.closest('.form-item').querySelector(`${SELECTOR_PREFIX_MESSAGE}required`);
     if (!elem) return this.valid;
     if (showError) {
+      this.dropdown.scrollIntoView({
+        behavior: 'smooth',
+        block: 'center',
+      });
       this.dropdown.setCustomValidity(`${elem.innerText}`);
       this.dropdown.reportValidity();
       this.form.setAttribute('data-show-error', 'false');

--- a/creativecloud/features/cc-forms/components/textfield.js
+++ b/creativecloud/features/cc-forms/components/textfield.js
@@ -145,11 +145,19 @@ class Textfield {
     this.textfield.setAttribute('data-valid', this.valid);
     if (this.required && this.value.trim() === '' && showError) {
       const elem = this.textfield.closest('.form-item').querySelector(`${SELECTOR_PREFIX_MESSAGE}required`);
+      this.textfield.scrollIntoView({
+        behavior: 'smooth',
+        block: 'center',
+      });
       this.textfield.setCustomValidity(`${elem.innerText}`);
       this.textfield.reportValidity();
       this.form.setAttribute('data-show-error', 'false');
     } else if (!this.valid && showError) {
       const elem = this.textfield.closest('.form-item').querySelector(`${SELECTOR_PREFIX_MESSAGE}invalid`);
+      this.textfield.scrollIntoView({
+        behavior: 'smooth',
+        block: 'center',
+      });
       this.textfield.setCustomValidity(`${elem.innerText}`);
       this.textfield.reportValidity();
     }


### PR DESCRIPTION
Error message and dropdown values rendered is not seen retained in device , shown as flash and disappear

Add your specific features or fixes
Resolves: [MWPW-165929](https://jira.corp.adobe.com/browse/MWPW-NUMBER)

Test URLs:
Before: https://main--cc--adobecom.aem.live/?martech=off
After: https://ccqa--cc--adobecom.aem.live/?martech=off
