### PR TITLE
MWPW-168352 error message displayed for the consent checkbox is not aliigned

### DIFF
--- a/creativecloud/blocks/cc-forms/cc-forms.css
+++ b/creativecloud/blocks/cc-forms/cc-forms.css
@@ -174,7 +174,7 @@
   inset: 0;
   cursor: pointer;
   z-index: 1;
-  width: auto;
+  width: fit-content;
 }
 
 .cc-forms .check-item-button {


### PR DESCRIPTION
Error message displayed for the consent checkbox is not aligned correctly lot of gap is shown and area is seen clickable

* Add your specific features or fixes

Resolves: [MWPW-168352](https://jira.corp.adobe.com/browse/MWPW-NUMBER)

**Test URLs:**
Before: https://main--cc--adobecom.aem.live/?martech=off
After: https://MWPW-168352--cc--adobecom.aem.live/?martech=off
