### PR TITLE
MWPW-168400 | Updated pdf api clientId

### DIFF
--- a/creativecloud/scripts/utils.js
+++ b/creativecloud/scripts/utils.js
@@ -371,7 +371,8 @@ const CONFIG = {
     psUrl: 'https://photoshop.adobe.com',
     odinEndpoint: 'https://odin.adobe.com/',
   },
-  page: { pdfViewerClientId: '7cb8376db6774989a4d549182e747890' },
+  // page: { pdfViewerClientId: '7cb8376db6774989a4d549182e747890' },
+  page: { pdfViewerClientId: 'a95510d4ce7d422fb9c95ab7eaa75169' },
   hlxPage: { pdfViewerClientId: 'b70362e4031e4fdfb4ad5ce1ffef61a0' },
   hlxLive: { pdfViewerClientId: 'fb748b00ec814d308f5115dbc1daeea5' },
   jarvis: {

--- a/creativecloud/scripts/utils.js
+++ b/creativecloud/scripts/utils.js
@@ -371,6 +371,9 @@ const CONFIG = {
     psUrl: 'https://photoshop.adobe.com',
     odinEndpoint: 'https://odin.adobe.com/',
   },
+  page: { pdfViewerClientId: '7cb8376db6774989a4d549182e747890' },
+  hlxPage: { pdfViewerClientId: 'b70362e4031e4fdfb4ad5ce1ffef61a0' },
+  hlxLive: { pdfViewerClientId: 'fb748b00ec814d308f5115dbc1daeea5' },
   jarvis: {
     id: 'adobedotcom2',
     version: '1.83',

--- a/creativecloud/scripts/utils.js
+++ b/creativecloud/scripts/utils.js
@@ -371,8 +371,7 @@ const CONFIG = {
     psUrl: 'https://photoshop.adobe.com',
     odinEndpoint: 'https://odin.adobe.com/',
   },
-  // page: { pdfViewerClientId: '9f6ffa6b76bf4c87a3e09e20b218d439' },
-  page: { pdfViewerClientId: '0ab18a7b18504176a041d1e58017e499' },
+  page: { pdfViewerClientId: '9f6ffa6b76bf4c87a3e09e20b218d439' },
   hlxPage: { pdfViewerClientId: 'b70362e4031e4fdfb4ad5ce1ffef61a0' },
   hlxLive: { pdfViewerClientId: 'fb748b00ec814d308f5115dbc1daeea5' },
   jarvis: {

--- a/creativecloud/scripts/utils.js
+++ b/creativecloud/scripts/utils.js
@@ -362,7 +362,7 @@ const CONFIG = {
     odinEndpoint: 'https://stage-odin.adobe.com/',
   },
   live: {
-    pdfViewerClientId: 'a26c77a2effb4c4aaa71e7c46385e0ed',
+    pdfViewerClientId: '9047b46d4bbe4033a0eed98f74d7d9d2',
     pdfViewerReportSuite: 'adbadobenonacdcqa',
   },
   prod: {
@@ -371,8 +371,8 @@ const CONFIG = {
     psUrl: 'https://photoshop.adobe.com',
     odinEndpoint: 'https://odin.adobe.com/',
   },
-  // page: { pdfViewerClientId: '7cb8376db6774989a4d549182e747890' },
-  page: { pdfViewerClientId: 'a95510d4ce7d422fb9c95ab7eaa75169' },
+  // page: { pdfViewerClientId: '9f6ffa6b76bf4c87a3e09e20b218d439' },
+  page: { pdfViewerClientId: '0ab18a7b18504176a041d1e58017e499' },
   hlxPage: { pdfViewerClientId: 'b70362e4031e4fdfb4ad5ce1ffef61a0' },
   hlxLive: { pdfViewerClientId: 'fb748b00ec814d308f5115dbc1daeea5' },
   jarvis: {


### PR DESCRIPTION
* Updated the pdf viewer api's clientid to support hlx.(page|live) aem.(page|live)

Resolves: [MWPW-168400](https://jira.corp.adobe.com/browse/MWPW-168400)

**Test URLs:**
- Before: https://main--cc--adobecom.aem.live/drafts/sharathkannan/12-ways-to-get-the-most-out-of-creative-cloud-for-teams?martech=off
- After: https://hlx5pdf--cc--sharath-kannan.aem.live/drafts/sharathkannan/12-ways-to-get-the-most-out-of-creative-cloud-for-teams?martech=off

PS: The pdfs in the above url can be viewed only after merging it to the main branch.
