### PR TITLE
MWPW-157950 | Migrating CC to unity V2 for performance and flexibility

### DIFF
--- a/creativecloud/blocks/unity/unity.js
+++ b/creativecloud/blocks/unity/unity.js
@@ -40,7 +40,6 @@ export default async function init(el) {
   const unitylibs = getUnityLibs();
   const promiseArr = [
     `${unitylibs}/core/styles/styles.css`,
-    `${unitylibs}/core/workflow/workflow.js`,
     `${unitylibs}/scripts/utils.js`,
     `${unitylibs}/core/workflow/workflow.js`,
   ];


### PR DESCRIPTION
Migrating CC to unity V2 for performance and flexibility - remove double loads

Resolves: [MWPW-157950](https://jira.corp.adobe.com/browse/MWPW-157950)

**Test URLs:**
- Before: https://main--cc--adobecom.aem.live/products/photoshop/edit-photos?martech=off
- After: https://unityv2migrationfix--cc--adobecom.aem.live/products/photoshop/edit-photos?martech=off
