### PR TITLE
Revert "MWPW-153103: creativecloud.adobe.com URLs not transforming during milo localization"

### DIFF
--- a/creativecloud/scripts/utils.js
+++ b/creativecloud/scripts/utils.js
@@ -347,7 +347,7 @@ const CONFIG = {
   imsClientId: 'adobedotcom-cc',
   locales,
   geoRouting: 'on',
-  prodDomains: ['www.adobe.com', 'helpx.adobe.com', 'business.adobe.com', 'creativecloud.adobe.com'],
+  prodDomains: ['www.adobe.com', 'helpx.adobe.com', 'business.adobe.com'],
   stageDomainsMap,
   decorateArea,
   adobeid: {


### PR DESCRIPTION
Reverts adobecom/cc#610

**Test URLs:**
- Before: https://main--cc--adobecom.hlx.live/nz/drafts/siva/learn?martech=off
- After: https://revert-610-mwpw-153103--cc--adobecom.hlx.live/nz/drafts/siva/learn?martech=off