### PR TITLE
Set explicit dir for AR

### DIFF
--- a/creativecloud/scripts/utils.js
+++ b/creativecloud/scripts/utils.js
@@ -23,7 +23,7 @@ const locales = {
   ae_ar: { ietf: 'ar-AE', tk: 'lpk1hwn.css', dir: 'rtl' },
   ae_en: { ietf: 'en', tk: 'hah7vzn.css' },
   africa: { ietf: 'en', tk: 'hah7vzn.css' },
-  ar: { ietf: 'ar', tk: 'lpk1hwn.css', dir: 'rtl' },
+  ar: { ietf: 'ar', tk: 'lpk1hwn.css', dir: 'ltr' },
   ar_es: { ietf: 'es-AR', tk: 'hah7vzn.css' },
   at: { ietf: 'de-AT', tk: 'hah7vzn.css' },
   au: { ietf: 'en-AU', tk: 'hah7vzn.css' },


### PR DESCRIPTION
This sets an explicit `dir` property for the AR locale. Not having a `dir` property doesn't work, as the fallback logic also assumes it as `rtl` for this locale.

Resolves: [MWPW-NUMBER](https://jira.corp.adobe.com/browse/MWPW-NUMBER)

**Test URLs:**
- Before: https://main--cc--adobecom.aem.page/ar/creativecloud?martech=off&georouting=off
- After: https://correct-ar-dir--cc--adobecom.aem.page/ar/creativecloud?martech=off&georouting=off
