### PR TITLE
Layout and styling updates

### DIFF
--- a/creativecloud/blocks/upload/upload.css
+++ b/creativecloud/blocks/upload/upload.css
@@ -33,7 +33,7 @@
   background: #FFF;
   border-radius: 10px;
   box-shadow: 0 0 20px 0 #00000029;
-  padding: 16px 16px 24px;
+  padding: 14px 14px 24px;
   position: relative;
   text-align: center;
   display: flex;
@@ -45,7 +45,7 @@
 .upload-block .drop-zone-container > p:last-child {
   font-size: 12px;
   line-height: 16px;
-  margin: 16px 0 0;
+  margin: 12px 0 0;
 }
 
 .upload-block .drop-zone {
@@ -54,12 +54,8 @@
   font-size: 14px;
   position: relative;
   margin-bottom: 24px;
-}
-
-.upload-block .drop-zone:hover {
-  border-color: #1473E6;
-  background-color: #E4F0FF;
-  cursor: pointer;
+  box-sizing: border-box;
+  border: 2px solid white;
 }
 
 .upload-block .drop-zone p:first-child {
@@ -69,7 +65,7 @@
 }
 
 .upload-block .drop-zone p:last-child {
-  margin: 0;
+  margin: 12px 0 0;
 }
 
 .upload-block .upload-action-container {
@@ -118,6 +114,11 @@
     display: none;
   }
 
+  .upload-block .media-container {
+    overflow: hidden;
+    border-radius: 16px;
+  }
+
   /* Drop Zone */
   .upload-block .drop-zone-container {
     width: 75%;
@@ -138,7 +139,11 @@
     overflow: hidden;
   }
 
-  /* Drop Zone */
+  .upload-block .media-container {
+    overflow: initial;
+    border-radius: none
+  }
+
   .upload-block .drop-zone-container {
     border-radius: 0;
     position: static;
@@ -155,8 +160,20 @@
     background-image: url("data:image/svg+xml,%3csvg width='100%25' height='100%25' xmlns='http://www.w3.org/2000/svg'%3e%3crect width='100%25' height='100%25' fill='none' rx='2' ry='8' stroke='silver' stroke-width='4' stroke-dasharray='5%2c 10' stroke-dashoffset='0' stroke-linecap='round'/%3e%3c/svg%3e");
   }
 
+  .upload-block .drop-zone:hover,
+  .upload-block .drop-zone.active {
+    border: 2px solid #1473E6;
+    background-color: #E4F0FF;
+    background-image: none;
+    cursor: pointer;
+  }
+
   .upload-block .drop-zone p:first-child {
     align-content: center;
+  }
+
+  .upload-block .drop-zone p:last-child {
+    margin: 0;
   }
 
   .upload-block .foreground > .upload-grid,

--- a/creativecloud/blocks/upload/upload.js
+++ b/creativecloud/blocks/upload/upload.js
@@ -59,7 +59,15 @@ function decorateBlockColumns(content) {
   dropZone.append(...paras);
   dropZoneContainer.append(dropZone, uploadEls, terms);
   content.append(mediaContainer, dropZoneContainer);
-
+  /* c8 ignore start */
+  dropZone.addEventListener('dragover', (e) => {
+    e.preventDefault();
+    dropZone.classList.add('active');
+  });
+  dropZone.addEventListener('dragleave', () => {
+    dropZone.classList.remove('active');
+  });
+  /* c8 ignore end */
   // Click button or drop zone to trigger file upload
   const clickEls = [uploadEls?.firstChild, dropZone];
   [...clickEls].forEach((el) => {


### PR DESCRIPTION
Adding the following style/layout updates to align with Figma for April workflow.

- Update drop-zone area to change dashed line to solid blue line on hover/drag over.
- Update vertical spacing for "file size" text on mobile and tablet.
- Update tablet breakpoint to add rounded corners to image/video.

Resolves: [MWPW-170983](https://jira.corp.adobe.com/browse/MWPW-170983)

**Test URLs:**
- Before: https://main--cc--adobecom.aem.live/drafts/rclayton/upload-poc?martech=off
- After: https://unity-upload-april-updates--cc--adobecom.aem.live/drafts/rclayton/upload-poc?martech=off
