### PR TITLE
chore: Configure Trusted Hosts for Sidekick

### DIFF
--- a/tools/sidekick/config.json
+++ b/tools/sidekick/config.json
@@ -2,6 +2,7 @@
   "project": "Creative Cloud",
   "previewHost": "main--cc--adobecom.aem.page",
   "liveHost": "main--cc--adobecom.aem.live",
+  "trustedHosts": ["milo.adobe.com"],
   "plugins": [
     {
       "id": "path",

--- a/tools/sidekick/config.json
+++ b/tools/sidekick/config.json
@@ -2,7 +2,7 @@
   "project": "Creative Cloud",
   "previewHost": "main--cc--adobecom.aem.page",
   "liveHost": "main--cc--adobecom.aem.live",
-  "trustedHosts": ["milo.adobe.com"],
+  "trustedHosts": ["milo.adobe.com", "main--milo--adobecom.aem.page"],
   "plugins": [
     {
       "id": "path",


### PR DESCRIPTION
Before: https://main--cc--adobecom.aem.live
After URL: https://trusted-hosts--cc--adobecom.aem.live?martech=off