### PR TITLE
MWPW-164486 download , signup analytics call is seen triggered even w…

### DIFF
--- a/creativecloud/features/cc-forms/forms/trials.js
+++ b/creativecloud/features/cc-forms/forms/trials.js
@@ -342,6 +342,8 @@ class Trials {
       if (this.valid) {
         this.circleLoaderShow(this.formContainer.querySelector(SELECTOR_BUTTON));
         setTimeout(() => { this.submitAction(); }, 1);
+      } else {
+        this.trackFormError();
       }
     });
   }
@@ -543,6 +545,29 @@ class Trials {
   toggleSubmitButton(disabled) {
     if (disabled) return this.submitButton.classList.add(BUTTON_DISABLED_CLASS);
     this.submitButton.classList.remove(BUTTON_DISABLED_CLASS);
+  }
+
+  trackFormError() {
+    // eslint-disable-next-line no-underscore-dangle
+    if (window._satellite) {
+      const formType = this.formContainer.getAttribute(DATA_FORM_TYPE) || 'Unknown';
+      const formName = formType.split('.')[1]
+        ? formType.split('.')[1].charAt(0).toUpperCase() + formType.split('.')[1].slice(1).toLowerCase()
+        : 'Unknown';
+      // eslint-disable-next-line no-underscore-dangle
+      window._satellite?.track('event', {
+        xdm: {},
+        data: {
+          web: {
+            webInteraction: {
+              name: `${formName} Form Error`,
+              type: 'other',
+              linkClicks: { value: 1 },
+            },
+          },
+        },
+      });
+    }
   }
 }
 


### PR DESCRIPTION
Download , signup analytics call is seen triggered even when there is error in dropdown

Resolves: [MWPW-164486](https://jira.corp.adobe.com/browse/MWPW-NUMBER)

**Test URLs:**
- Before: https://main--cc--adobecom.hlx.live/drafts/mathuria/dalpforms/perpeptual#
- After: https://forms-error-analytics--cc--adobecom.hlx.live/drafts/mathuria/dalpforms/perpeptual#
