### PR TITLE
MWPW-170275 & MWPW-171455 | Connect form treatmentid and purchase intent dropdown fix

### DIFF
--- a/creativecloud/features/cc-forms/components/dropdown.js
+++ b/creativecloud/features/cc-forms/components/dropdown.js
@@ -67,7 +67,7 @@ class Dropdown {
       },
       'connect-purchase-intent': {
         'dropdown-name': 'connectpurchaseintent',
-        'dropdown-source': `graphql/execute.json/acom/fieldvalues;path=/content/dam/acom/connecttrialpurchaseintent/us/en`,
+        'dropdown-source': 'graphql/execute.json/acom/fieldvalues;path=/content/dam/acom/connecttrialpurchaseintent/us/en',
       },
       country: {
         'dropdown-name': 'country',

--- a/creativecloud/features/cc-forms/components/dropdown.js
+++ b/creativecloud/features/cc-forms/components/dropdown.js
@@ -67,7 +67,7 @@ class Dropdown {
       },
       'connect-purchase-intent': {
         'dropdown-name': 'connectpurchaseintent',
-        'dropdown-source': `graphql/execute.json/acom/fieldvalues;path=/content/dam/acom/connecttrialpurchaseintent/${odinLocale}`,
+        'dropdown-source': `graphql/execute.json/acom/fieldvalues;path=/content/dam/acom/connecttrialpurchaseintent/us/en`,
       },
       country: {
         'dropdown-name': 'country',

--- a/creativecloud/features/cc-forms/forms/connect.js
+++ b/creativecloud/features/cc-forms/forms/connect.js
@@ -114,6 +114,12 @@ class ConnectTrials extends Trials {
     } else {
       tid = UNKNOWN;
     }
+    if (
+      tid !== UNKNOWN
+      && (tid.trim().length === 0 || tid.trim().search('^[0-9a-z A-Z-/]*$') === -1)
+    ) {
+      tid = UNKNOWN;
+    }
     return tid;
   }
 


### PR DESCRIPTION
* Connect form submission failing if treatment id is set to a invalid format value. Adding a validation check as configured in backend to avoid invalid payload issue.
* Connect purchase intent dropdown needs to populate from en content. Making the odin endpoint explicitly point to us.

Resolves:
[MWPW-170275](https://jira.corp.adobe.com/browse/MWPW-170275)
[MWPW-171455](https://jira.corp.adobe.com/browse/MWPW-171455)

**Test URLs:**
- Before: https://main--cc--adobecom.aem.live/?martech=off
- After: https://MWPW-171455--cc--adobecom.aem.live/?martech=off

Test URL - 
https://dev--cc--adobecom.aem.page/drafts/mathuria/dalpforms/connect
