### PR TITLE
MWPW-172492: fixed multiple link text for a11y

### DIFF
--- a/creativecloud/features/interactive-components/selector-tray/selector-tray.js
+++ b/creativecloud/features/interactive-components/selector-tray/selector-tray.js
@@ -20,7 +20,11 @@ function getStartingPathIdx(data) {
 function createSelectorThumbnail(pic, pathId, displayImg) {
   const src = getImgSrc(pic);
   const outline = createTag('div', { class: 'tray-thumbnail-outline' });
-  const a = createTag('a', { class: 'tray-thumbnail-img', href: '#' }, outline);
+  const a = createTag('a', {
+    class: 'tray-thumbnail-img',
+    href: '#',
+    ...(pic.querySelector('img') && pic.querySelector('img').alt && { 'aria-label': pic.querySelector('img').alt }),
+  }, outline);
   a.style.backgroundImage = `url(${src})`;
   [a.dataset.dispSrc, a.dataset.dispAlt] = displayImg;
   a.dataset.dispPth = pathId;


### PR DESCRIPTION
-  Fixed multiple links have the same programmatic link text but different destinations. 

Resolves: [MWPW-172492](https://jira.corp.adobe.com/browse/MWPW-172492)

**Test URLs:**
- Before: https://main--cc--adobecom.aem.live/?martech=off
- After: https://mwpw-172492-interactive-marquee--cc--adobecom.aem.live/?martech=off
