### PR TITLE
MWPW-173290 | Prevent dropdown arrow overlap with content for rtl locale

### DIFF
--- a/creativecloud/blocks/cc-forms/cc-forms.css
+++ b/creativecloud/blocks/cc-forms/cc-forms.css
@@ -133,6 +133,10 @@
   background-size: 1em 1em;
 }
 
+[dir='rtl'] .cc-forms select {
+  background-position: 2% 50%;
+}
+
 .cc-forms label {
   display: block;
   padding-bottom: var(--spacing-xxs);


### PR DESCRIPTION
Prevent dropdown arrow overlap with content for rtl locale

Resolves: [MWPW-173290](https://jira.corp.adobe.com/browse/MWPW-173290)

**Test URLs:**
- Before: https://main--cc--adobecom.aem.live/?martech=off
- After: https://MWPW-173290--cc--adobecom.aem.live/?martech=off

https://dev--cc--adobecom.aem.page/drafts/mathuria/dalpforms/perpeptual
