### PR TITLE
MWPW-173695 and MWPW-173696 unsubscribe forms

### DIFF
--- a/creativecloud/features/cc-forms/forms/unsubscribe.js
+++ b/creativecloud/features/cc-forms/forms/unsubscribe.js
@@ -63,6 +63,17 @@ class Unsubscribe extends Trials {
           handleCheckboxChange(elem, index);
         }
       });
+
+      const spanButton = elem.nextElementSibling;
+      if (spanButton && spanButton.classList.contains('checkbox-button')) {
+        spanButton.addEventListener('keydown', (event) => {
+          if (event.key === 'Enter' || event.key === ' ') {
+            event.preventDefault();
+            elem.checked = !elem.checked;
+            handleCheckboxChange(elem, index);
+          }
+        });
+      }
     });
   }
 

--- a/creativecloud/features/cc-forms/forms/unsubscribe.js
+++ b/creativecloud/features/cc-forms/forms/unsubscribe.js
@@ -42,13 +42,26 @@ class Unsubscribe extends Trials {
     const unsubscribeForm = this;
     const { form } = this;
     const checkboxes = this.form.querySelectorAll(CHECKBOX_INPUT_CLASS);
+
+    const handleCheckboxChange = (checkbox, index) => {
+      if (checkbox.checked) {
+        checkboxes[index ? 0 : 1].checked = false;
+      }
+      const checkboxChecked = form.querySelector(CHECKBOX_INPUT_CHECKED);
+      unsubscribeForm.toggleSubmitButton(!(checkboxChecked instanceof HTMLElement));
+    };
+
     Array.prototype.forEach.call(checkboxes, (elem, index) => {
       elem.addEventListener('change', (elemChanged) => {
-        if (elemChanged.target.checked) {
-          checkboxes[index ? 0 : 1].checked = false;
+        handleCheckboxChange(elemChanged.target, index);
+      });
+
+      elem.addEventListener('keydown', (event) => {
+        if (event.key === 'Enter' || event.key === ' ') {
+          event.preventDefault();
+          elem.checked = !elem.checked;
+          handleCheckboxChange(elem, index);
         }
-        const checkboxChecked = form.querySelector(CHECKBOX_INPUT_CHECKED);
-        unsubscribeForm.toggleSubmitButton(!(checkboxChecked instanceof HTMLElement));
       });
     });
   }
@@ -68,7 +81,7 @@ class Unsubscribe extends Trials {
     data.p = this.getParam('p');
     data.n = this.getParam('n');
     data.src = this.getParam('src');
-    if (this.getParam('type') !== 'instructional' && this.getParam('sname') === null) {
+    if (this.getParam('type') !== 'instructional' && this.getParam('sname') === undefined) {
       data.type = 'marketing';
     }
     if (this.form.querySelector('.checkbox-input#unsubscribe-all:checked')) {


### PR DESCRIPTION
* [Accessibility]checkbox selection via space bar and enter is not seen functioning in unsubscribe url
*unsubscribe flow for Adobe Promotional Marketing email communications service is seen redirecting to 404

Resolves: [MWPW-173696](https://jira.corp.adobe.com/browse/MWPW-NUMBER)

Test URLs:

Before: https://main--cc--adobecom.aem.page/drafts/suhjain/forms/unsubscribe
After: https://mwpw-173695--cc--adobecom.aem.live/

Testing links:
/drafts/suhjain/forms/unsubscribe?p=QvTylbSZMKjEOgdnTDj%2FcXFRp4rfULx3c6nlD%2FTp7H3ZC4uziIcucjD1%2BnuhMBff0rbACuff37ei5QOKm8in1vfqh1Y%2F4FLjYRD1D0Gl3iZ2R5yQy1VDh35gb9HZunoVZpGDjm3Kk0QN6O%2BqqpmRA6RC4n7Yj%2BSUE%2BetlXJWgWBCQ%2BatWSWMgLmrwnJZnrwMWQ%3D%3D&src=aci&type=macrupdates&n=sV0eIhWBHdVZH5qvsTHAkw%3D%3D&email=d******5%40at.com&legacy=false#
