### PR TITLE
MWPW-173532: Fixed select a variation tray for a11y

### DIFF
--- a/creativecloud/features/interactive-components/selector-tray/selector-tray.js
+++ b/creativecloud/features/interactive-components/selector-tray/selector-tray.js
@@ -36,22 +36,6 @@ function createSelectorThumbnail(pic, pathId, displayImg) {
   return a;
 }
 
-/**
- * Enables arrow key navigation for a group of elements with role="radio" within a container.
- *
- * @param {HTMLElement} container - The container element that holds the radio-role items.
- *
- * @description
- * This function adds a keyboard event listener to the container to handle arrow key presses:
- * - ArrowRight and ArrowDown move focus to the next radio item.
- * - ArrowLeft and ArrowUp move focus to the previous radio item.
- * Focus wraps around when reaching the first or last item.
- *
- * It queries all child elements with `role="radio"` inside the container to manage focus movement.
- * This enhances accessibility by allowing keyboard users to navigate between radio options
- * using arrow keys.
- */
-
 function attachArrowNavigation(container) {
   const getRadioItems = () => Array.from(container.querySelectorAll('a[role="radio"]'));
 

--- a/creativecloud/features/interactive-components/selector-tray/selector-tray.js
+++ b/creativecloud/features/interactive-components/selector-tray/selector-tray.js
@@ -36,6 +36,22 @@ function createSelectorThumbnail(pic, pathId, displayImg) {
   return a;
 }
 
+/**
+ * Enables arrow key navigation for a group of elements with role="radio" within a container.
+ *
+ * @param {HTMLElement} container - The container element that holds the radio-role items.
+ *
+ * @description
+ * This function adds a keyboard event listener to the container to handle arrow key presses:
+ * - ArrowRight and ArrowDown move focus to the next radio item.
+ * - ArrowLeft and ArrowUp move focus to the previous radio item.
+ * Focus wraps around when reaching the first or last item.
+ *
+ * It queries all child elements with `role="radio"` inside the container to manage focus movement.
+ * This enhances accessibility by allowing keyboard users to navigate between radio options
+ * using arrow keys.
+ */
+
 function attachArrowNavigation(container) {
   const getRadioItems = () => Array.from(container.querySelectorAll('a[role="radio"]'));
 


### PR DESCRIPTION
- Improved accessibility of ‘Select a variation’ by adding ARIA roles and arrow key navigation for better screen reader support.

Resolves: [MWPW-173532](https://jira.corp.adobe.com/browse/MWPW-173532)
Also Resolves: [MWPW-172065](https://jira.corp.adobe.com/browse/MWPW-172065)

**Test URLs:**
- Before: https://main--cc--adobecom.aem.live/?martech=off
- After: https://mwpw-173532-select-variation-a11y--cc--adobecom.aem.live/?martech=off