### PR TITLE
[MWPW-173820] Fixed - No spacing between the consent text and check box for arabic locales in forms

### DIFF
--- a/creativecloud/blocks/cc-forms/cc-forms.css
+++ b/creativecloud/blocks/cc-forms/cc-forms.css
@@ -257,6 +257,10 @@
   width: auto;
 }
 
+html[dir="rtl"] .cc-forms .check-item-label {
+  margin-right: var(--spacing-xxs);
+}
+
 .cc-forms .cc-forms-legal-wrapper p {
   font-size: var(--type-body-xxs-size);
   line-height: var(--type-body-xxs-lh);


### PR DESCRIPTION
Resolves: [MWPW-173820](https://jira.corp.adobe.com/browse/MWPW-173820)

**Test URLs:**
- Before: https://main--cc--adobecom.aem.live/?martech=off
- After: https://mwpw-173820--cc--adobecom.aem.live/?martech=off

Url:
https://www.stage.adobe.com/mena_ar/creativecloud/animation/testdoc/syt/connect.html#