### PR TITLE
MWPW-174164: Catalog collection block backward compatibility changes

### DIFF
--- a/creativecloud/blocks/catalog/catalog.css
+++ b/creativecloud/blocks/catalog/catalog.css
@@ -1,31 +1,26 @@
 .catalog.app {
-  display: flex;
-  min-height: 400px;
+  display: grid;
+  grid-template-columns: min-content auto;
+  grid-template-areas: 'sidenav header' 'sidenav content';
   justify-content: center;
+  min-height: 400px;
 }
 
-
 @media screen and (min-width: 1200px) {
-  .catalog.app {
-    display: grid;
-    gap: 36px;
-    grid-template-columns: 240px auto;
-    min-height: 400px;
-  }
-
-  merch-sidenav {
-    min-width: 240px;
+  .collection-container.catalog {
+    --merch-card-collection-sidenav-margin: 36px;
   }
 }
 
 .catalog.app > merch-sidenav {
-  grid-column: 1 / span 1;
-  order: 0;
+  grid-area: sidenav;
+}
+
+.catalog.app > merch-card-collection-header {
+  grid-area: header;
 }
 
 .catalog.app > merch-card-collection {
-  align-self: baseline;
-  grid-column: 2 / span 1;
-  order: 1;
+  grid-area: content;
   padding: 0;
 }

--- a/creativecloud/blocks/catalog/catalog.js
+++ b/creativecloud/blocks/catalog/catalog.js
@@ -70,7 +70,7 @@ export function enableAnalytics(catalog, merchCards, sidenav) {
 /** container block */
 export default async function init(el) {
   await polyfills();
-  el.classList.add('app');
+  el.classList.add('collection-container', 'app');
   const libs = getLibs();
   const sidenavEl = el.querySelector('.sidenav');
   const merchCardsEl = el.querySelector('.merch-card-collection');

--- a/creativecloud/blocks/sidenav/sidenav.js
+++ b/creativecloud/blocks/sidenav/sidenav.js
@@ -206,5 +206,7 @@ export default async function init(el) {
     await makePause();
     appendResources(rootNav, resourcesLink);
   }
+  const collection = document.querySelector('merch-card-collection');
+  collection?.attachSidenav(rootNav, false);
   return rootNav;
 }


### PR DESCRIPTION
The milo collection component was split into 2 (header + content). The collection block has had some changes as well, and the catalog/sidenav blocks need to be updated for that.

Resolves: [MWPW-174164](https://jira.corp.adobe.com/browse/MWPW-174164)

**Test URLs:**
- Before: https://main--cc--adobecom.aem.live/products/catalog?martech=off
- After: https://mwpw-174164--cc--adobecom.aem.live/products/catalog?martech=off&milolibs=mwpw-174164
