### PR TITLE
MWPW-175156: fix sidenav requesting hlx.live

### DIFF
--- a/creativecloud/blocks/sidenav/sidenav.js
+++ b/creativecloud/blocks/sidenav/sidenav.js
@@ -195,7 +195,7 @@ export default async function init(el) {
   appendSearch(rootNav, searchText);
   if (endpoint) {
     await makePause();
-    endpoint = localizeLink(endpoint.textContent.trim(), null, true);
+    endpoint = localizeLink(endpoint.href, null, true);
     const explicitCategories = categoryRow?.querySelector('ul');
     performance.mark('sidenav:appendFilters:start');
     await appendFilters(rootNav, endpoint, explicitCategories, typeText);

--- a/test/blocks/sidenav/sidenav.test.html
+++ b/test/blocks/sidenav/sidenav.test.html
@@ -66,7 +66,7 @@
           </div>
           <div>
               <div>
-                <p><a href="/some/taxonomy.json">https://www.adobe.com//some/taxonomy.json</a></p>
+                <p><a href="/some/taxonomy.json">Taxonomy Link</a></p>
                 <ul>
                   <li>All <picture><img loading="lazy" src="mocks/blah.svg"></picture></li>
                   <li>Photo</li>

--- a/test/blocks/sidenav/sidenav.test.html.js
+++ b/test/blocks/sidenav/sidenav.test.html.js
@@ -65,17 +65,30 @@ runTests(async () => {
     });
 
     it('does create nice plans sidenav', async () => {
-      const sidenavEl = document.querySelector('.plans');
-      const newRoot = await init(sidenavEl);
-      expect(newRoot.tagName).to.equal('MERCH-SIDENAV');
-      expect(newRoot.sidenavTitle).to.equal('CATEGORIES');
-      const search = newRoot.querySelector('sp-search');
-      expect(search).to.be.null;
-      const nestedItems = newRoot.querySelectorAll('sp-sidenav-item > sp-sidenav-item');
-      expect(nestedItems.length).to.equal(0);
-      const iconItem = newRoot.querySelector('sp-sidenav-item[value=all] > picture');
-      expect(iconItem).to.not.be.null;
-      expect(iconItem.getAttribute('slot')).to.equal('icon');
+      // Mock fetch to capture the URL being called
+      let capturedUrl = null;
+      const originalFetch = window.fetch;
+      window.fetch = sinon.stub().callsFake((url) => {
+        capturedUrl = url;
+        return mockedTaxonomy();
+      });
+      try {
+        const sidenavEl = document.querySelector('.plans');
+        const newRoot = await init(sidenavEl);
+        expect(newRoot.tagName).to.equal('MERCH-SIDENAV');
+        expect(newRoot.sidenavTitle).to.equal('CATEGORIES');
+        const search = newRoot.querySelector('sp-search');
+        expect(search).to.be.null;
+        const nestedItems = newRoot.querySelectorAll('sp-sidenav-item > sp-sidenav-item');
+        expect(nestedItems.length).to.equal(0);
+        const iconItem = newRoot.querySelector('sp-sidenav-item[value=all] > picture');
+        expect(iconItem).to.not.be.null;
+        expect(iconItem.getAttribute('slot')).to.equal('icon');
+        expect(capturedUrl).to.include('/some/taxonomy.json');
+        expect(capturedUrl).to.not.include('Taxonomy Link');
+      } finally {
+        window.fetch = originalFetch;
+      }
     });
   });
 });


### PR DESCRIPTION
fix taxonomy link to be taken from href, not link text
this was causing Catalog page to request hlx.live url from www.adobe.com

Resolves: [MWPW-175156](https://jira.corp.adobe.com/browse/MWPW-175156)

**Test URLs:**
- Before: https://main--cc--adobecom.aem.live/?martech=off
- After: https://MWPW-175156--cc--adobecom.aem.live/?martech=off
