### PR TITLE
MWPW-177234: update hlx.page to aem.page

### DIFF
--- a/.github/preview-index/src/sharepoint.js
+++ b/.github/preview-index/src/sharepoint.js
@@ -35,7 +35,6 @@ const PREVIEW_LOCALES = process.env.PREVIEW_LOCALES;
 const ENABLED = process.env.ENABLED;
 
 const PREVIEW_STATUS_URL = `https://admin.hlx.page/status/adobecom/${CONSUMER}/main/*`;
-const PREVIEW_UPDATE_URL = `https://admin.hlx.page/preview/adobecom/${CONSUMER}/main/${PREVIEW_INDEX_JSON}`;
 const PREVIEW_BASE_URL = `https://main--${CONSUMER}--adobecom.aem.page`;
 const GRAPH_BASE_URL = 'https://graph.microsoft.com/v1.0';
 const SHEET_RAW_INDEX = 'raw_index';
@@ -198,7 +197,7 @@ const getItemId = async (indexPath) => {
 
 const previewIndex = async (locale) => {
   const previewIndexJson = locale ? `${locale}/${PREVIEW_INDEX_JSON}` : PREVIEW_INDEX_JSON;
-  const PREVIEW_UPDATE_URL = `https://admin.hlx.page/preview/adobecom/${CONSUMER}/main/${previewIndexJson}`;
+  const PREVIEW_UPDATE_URL = `https://admin.aem.page/preview/adobecom/${CONSUMER}/main/${previewIndexJson}`;
   console.log('Preview update url: ' + PREVIEW_UPDATE_URL);
   const previewResponse = await fetch(PREVIEW_UPDATE_URL, {
     method: 'POST',


### PR DESCRIPTION
Updates the preview request path to aem.page since https://main--cc--adobecom.aem.page/cc-shared/assets/query-index-cards-preview.json?sheet=catalog is used for preview in the catalog page.

Resolves: [MWPW-177234](https://jira.corp.adobe.com/browse/MWPW-177234)

**Test URLs:**
- Before: https://main--cc--adobecom.aem.live/?martech=off
- After: https://mwpw-177234--cc--adobecom.aem.live/?martech=off
