### PR TITLE
[MWPW-177333]Move blocks that need to avoid loading icons.js and css file to consuming team config

### DIFF
--- a/creativecloud/scripts/utils.js
+++ b/creativecloud/scripts/utils.js
@@ -367,6 +367,7 @@ const CONFIG = {
   contentRoot: '/cc-shared',
   codeRoot: '/creativecloud',
   imsClientId: 'adobedotcom-cc',
+  excludeIconsBlock: ['unity', 'cc-forms', 'interactive-metadata'],
   locales,
   geoRouting: 'on',
   prodDomains: ['www.adobe.com', 'helpx.adobe.com', 'business.adobe.com'],


### PR DESCRIPTION
* Move blocks that need to avoid loading icons.js and css file to consuming team config

Resolves: [MWPW-177333](https://jira.corp.adobe.com/browse/MWPW-177333)

**Test URLs:**
- Before: https://stage--cc--adobecom.aem.live/products/firefly?milolibs=exclude-icons&martech=off
- After: https://exclude-icons--cc--adobecom.aem.live/products/firefly?milolibs=exclude-icons&martech=off

