### PR TITLE
MWPW-177234: revert aem admin url

### DIFF
--- a/.github/preview-index/src/sharepoint.js
+++ b/.github/preview-index/src/sharepoint.js
@@ -197,7 +197,7 @@ const getItemId = async (indexPath) => {
 
 const previewIndex = async (locale) => {
   const previewIndexJson = locale ? `${locale}/${PREVIEW_INDEX_JSON}` : PREVIEW_INDEX_JSON;
-  const PREVIEW_UPDATE_URL = `https://admin.aem.page/preview/adobecom/${CONSUMER}/main/${previewIndexJson}`;
+  const PREVIEW_UPDATE_URL = `https://admin.hlx.page/preview/adobecom/${CONSUMER}/main/${previewIndexJson}`;
   console.log('Preview update url: ' + PREVIEW_UPDATE_URL);
   const previewResponse = await fetch(PREVIEW_UPDATE_URL, {
     method: 'POST',


### PR DESCRIPTION
this PR has no impact to CC website.

Resolves: [MWPW-177234](https://jira.corp.adobe.com/browse/MWPW-177234)

**Test URLs:**
- Before: https://main--cc--adobecom.aem.live/?martech=off
- After: https://mwpw-177234-2--cc--adobecom.aem.live/?martech=off
