### PR TITLE
MWPW-178443 CC Config - acom benefits folder should not have .html appended

### DIFF
--- a/creativecloud/scripts/utils.js
+++ b/creativecloud/scripts/utils.js
@@ -406,6 +406,7 @@ const CONFIG = {
     /www\.adobe\.com\/(\w\w(_\w\w)?\/)?express(\/.*)?/,
     /www\.adobe\.com\/(\w\w(_\w\w)?\/)?go(\/.*)?/,
     /www\.adobe\.com\/(\w\w(_\w\w)?\/)?learn(\/.*)?/,
+    /www\.adobe\.com\/(\w\w(_\w\w)?\/)?benefits(\/.*)?/,
   ],
   brandConciergeAA: 'cc:app-reco',
 };


### PR DESCRIPTION
* benefits folder added to the exclusion list

Resolves: [MWPW-178443](https://jira.corp.adobe.com/browse/MWPW-178443)

**Test URLs:**
- Before: https://main--cc--adobecom.aem.live/?martech=off
- After: https://excludebenefits--cc--adobecom.aem.live/?martech=off

https://adobedotcom.slack.com/archives/C03B0BUA75E/p1755138019783219