### PR TITLE
MWPW-172104 [Kodiak][R2]: DOMXSS in [github.com/adobecom/cc-sandbox]

### DIFF
--- a/test/blocks/universal-promo-terms/mocks/xss.html
+++ b/test/blocks/universal-promo-terms/mocks/xss.html
@@ -1,0 +1,5 @@
+<div>
+  <script>alert('A')</script>
+  <div onClick="alert('B')">text</div>
+  <div>text <a href="javascript:alert('C')">link</a></div>
+</div>

--- a/test/blocks/universal-promo-terms/universal.promo.terms.test.js
+++ b/test/blocks/universal-promo-terms/universal.promo.terms.test.js
@@ -3,7 +3,7 @@ import { expect } from '@esm-bundle/chai';
 import sinon from 'sinon';
 
 document.body.innerHTML = await readFile({ path: './mocks/body.html' });
-const { default: init } = await import('../../../creativecloud/blocks/universal-promo-terms/universal-promo-terms.js');
+const { default: init, sanitize } = await import('../../../creativecloud/blocks/universal-promo-terms/universal-promo-terms.js');
 
 describe('universal-promo-terms', () => {
   const block = document.body.querySelector('.universal-promo-terms');
@@ -18,5 +18,12 @@ describe('universal-promo-terms', () => {
   it('Get API from query parameters', async () => {
     await init(block, '?offer_id=1B365A793986BBEEE26F3E372BDAAB09&locale=de_DE&promotion_code=fixed_dis_20&country=DE&env=stage');
     expect(document.querySelector('.universal-promo-terms').textContent).to.not.equal('false');
+  });
+
+  it('Sanitize HTML',  async () => {
+    const htmlXss = await readFile({ path: './mocks/xss.html' });
+    expect(htmlXss.includes('alert')).to.be.true;
+    const html = sanitize(htmlXss);
+    expect(html.innerHTML.includes('alert')).to.be.false;
   });
 });


### PR DESCRIPTION
The component `universal promo terms` loads some HTML with request `https://aos-stage.adobe.io/offers/...` which returns some HTML that is then injected into the page. That HTML is now sanitized (XSS prevented) :

- all `script` tags removed
- all potentially dangerous attributes removed

Resolves: [MWPW-172104](https://jira.corp.adobe.com/browse/MWPW-172104)

Test page : `main--cc--adobecom.aem.page/uk/offers/promo-terms?locale=fr_FR&service_providers=PROMO_TERMS&country=FR&api_key=PlatformDocs&offer_id=00AD23F3606079A216964E5F3DAB08E7&promo_context=initial_purchase&campaignEnd=2025/6/3#`

**Test URLs:**
- Before: https://main--cc--adobecom.aem.live/?martech=off
- After: https://mwpw172104xss--cc--adobecom.aem.live/?martech=off
