### PR TITLE
MWPW-181890 Fixed FFGallery overlay colliding with promobar

### DIFF
--- a/creativecloud/blocks/firefly-gallery/firefly-gallery.css
+++ b/creativecloud/blocks/firefly-gallery/firefly-gallery.css
@@ -91,7 +91,7 @@
   position: absolute;
   bottom: 0;
   left: 0;
-  z-index: 5;
+  z-index: 3;
   width: 100%;
 }
 


### PR DESCRIPTION
* Corrected z-index for ff-gallery overlay which was conflicting with promobar

Dev validation:
<img width="1040" height="1045" alt="fix-z-index-overlay-promobar" src="https://github.com/user-attachments/assets/528ec275-1ebe-4bcb-baf9-1e9a654aea76" />


Resolves: https://jira.corp.adobe.com/browse/MWPW-181890

**Test URLs:**
- Before: https://main--cc--adobecom.aem.live/drafts/nthakur/ff-video-gallery-poc?martech=off
- After: https://mwpw-181890-ffgallery-overlay--cc--adobecom.aem.live/drafts/nthakur/ff-video-gallery-poc?martech=off
