### PR TITLE
MWPW-191532: [Doodlebug] Adjust section heading typography

### DIFF
--- a/creativecloud/blocks/firefly-share/firefly-share.css
+++ b/creativecloud/blocks/firefly-share/firefly-share.css
@@ -262,7 +262,7 @@ main > .section.center firefly-share.inline ul.icon-container {
   }
 
   .firefly-share.xxl-heading :is([role="heading"], h1, h2, h3, h4, h5, h6) {
-    font-size: 40px;
+    font-size: 44px;
   }
 
   .firefly-share ul.icon-container {

--- a/creativecloud/styles/doodlebug.css
+++ b/creativecloud/styles/doodlebug.css
@@ -593,7 +593,7 @@
 
     @media (min-width: 1200px) {
         .text-block [class*="heading-xxxl"] {
-            font-size: 4rem;
+            font-size: 2.75rem;
             line-height: 98%;
             letter-spacing: -2.88px;
         }


### PR DESCRIPTION
* Adjust large heading typography in Firefly Share and Doodlebug
* Increase `.firefly-share.xxl-heading` font size from `40px` to `44px`
* Reduce Doodlebug `heading-xxxl` desktop font size from `4rem` to `2.75rem` for better visual balance

Resolves: [MWPW-191532](https://jira.corp.adobe.com/browse/MWPW-191532)

**Test URLs:**
- Before: https://main--cc--adobecom.aem.live/products/firefly/features/remove-object-from-photo?martech=off
- After: https://MWPW-191532-h2-font-size--cc--adobecom.aem.live/products/firefly/features/remove-object-from-photo?martech=off

**Dev validation**
<img width="972" height="391" alt="share-font-size" src="https://github.com/user-attachments/assets/b197ad59-2e80-4545-aa91-6f4174507727" />

<img width="878" height="379" alt="h2-font-size" src="https://github.com/user-attachments/assets/25202911-393d-4421-b79c-4ff928c0c5f0" />

Note that in notifications-banner, even though the text is **h2**, its font-size is not updated
<img width="862" height="509" alt="notif-font-size" src="https://github.com/user-attachments/assets/4091038b-39f9-4fad-a243-86cb57a10323" />
