### PR TITLE
[CC-Only][MWPW-189322] - Update ContentRoot

### DIFF
--- a/creativecloud/scripts/utils.js
+++ b/creativecloud/scripts/utils.js
@@ -385,7 +385,7 @@ export async function acomsisCookieHandler() {
 export const decorateArea = getDecorateAreaFn();
 
 const CONFIG = {
-  contentRoot: '/cc-shared',
+  contentRoot: '/creativecloud/plans/merch-shared',
   codeRoot: '/creativecloud',
   imsClientId: 'adobedotcom-cc',
   iconsExcludeBlocks: ['unity', 'cc-forms', 'interactive-metadata'],


### PR DESCRIPTION
## Summary                                                                                                   
  Repoints CC's `contentRoot` from `/cc-shared` to `/creativecloud/plans/merch-shared` so the Plans area
  sources its shared content (gnav, placeholders, georouting, query indexes, SEO links) from the new           
  merch-shared location under `/creativecloud/plans/`.
                                                                                                               
  Resolves: [MWPW-189322](https://jira.corp.adobe.com/browse/MWPW-189322)                                      
  Context discussion: [Slack thread](https://adobe-mwp.slack.com/archives/C08DVHSFBPV/p1775603339625159?thread_ts=1775575049.049479&cid=C08DVHSFBPV)                                                                        
                                                      
  ## What changes                                                                                              
  One-line config update in `creativecloud/scripts/utils.js`. `contentRoot` is consumed by Milo's `utils.js` to
   build per-locale URLs for:                                                                                  
  - `locale.contentRoot` (base for locale-scoped fetches)
  - `gnav` source (`${contentRoot}/gnav`)                                                                      
  - placeholders (`${contentRoot}/placeholders.json`)                                                          
  - `georoutingv2.json`                                                                                        
  - query indexes (`queryIndexPath`)                                                                           
  - SEO `links.json`                                                                                           
                                                                                                               
  ## Why                                                                                                       
  <one-liner on the migration driver>          
                                                                                                               
  ## Risk & scope                                                                                              
  Touches one config value, but the blast radius covers every CC page that pulls shared content through Milo's
  resolver. Mitigations:                                                                                       
  - Mirror content exists at `/creativecloud/plans/merch-shared/{gnav,placeholders,georoutingv2.json,...}`
  before merge                                                                                                 
  - Verified on stage with side-by-side compare against main
  - Rollback = revert this single line                                                                         
                                                                                                               
 ## Test URLs        
  **Catalog** (`/products/catalog-dotcom-179540-test`)                      
  - Before: https://main--cc--adobecom.aem.live/products/catalog-dotcom-179540-test
  - After:  https://plans--cc--adobecom.aem.live/products/catalog-dotcom-179540-test                           
                                                                                                               
  **Plans** (`/creativecloud/plans-dotcom-179540-test`)                                                        
  - Before: https://main--cc--adobecom.aem.live/creativecloud/plans-dotcom-179540-test                         
  - After:  https://plans--cc--adobecom.aem.live/creativecloud/plans-dotcom-179540-test 