### PR TITLE
MWPW-191633: Adds to setLibs array to allow the use of milolibs= on stage

### DIFF
--- a/creativecloud/scripts/utils.js
+++ b/creativecloud/scripts/utils.js
@@ -169,11 +169,7 @@ export const [setLibs, getLibs] = (() => {
         return libs;
       }
       const { hostname } = window.location;
-      if (!hostname.includes('hlx.page')
-        && !hostname.includes('hlx.live')
-        && !hostname.includes('aem.page')
-        && !hostname.includes('aem.live')
-        && !hostname.includes('localhost')) {
+      if (!['.aem.', '.hlx.', '.stage.', 'local', '.da.'].some((i) => hostname.includes(i))) {
         libs = prodLibs;
         return libs;
       }

--- a/creativecloud/scripts/utils.js
+++ b/creativecloud/scripts/utils.js
@@ -169,7 +169,7 @@ export const [setLibs, getLibs] = (() => {
         return libs;
       }
       const { hostname } = window.location;
-      if (!['.aem.', '.hlx.', '.stage.', 'local', '.da.'].some((i) => hostname.includes(i))) {
+      if (!['.aem.', '.hlx.', '.stage.', 'localhost', '.da.'].some((i) => hostname.includes(i))) {
         libs = prodLibs;
         return libs;
       }

--- a/creativecloud/scripts/utils.js
+++ b/creativecloud/scripts/utils.js
@@ -175,6 +175,7 @@ export const [setLibs, getLibs] = (() => {
       }
       const branch = new URLSearchParams(window.location.search).get('milolibs') || 'main';
       if (branch === 'local') { libs = 'http://localhost:6456/libs'; return libs; }
+      if (branch === 'main' && hostname.includes('.stage.')) return '/libs';
       const env = hostname.includes('.hlx.') ? 'hlx' : 'aem';
       if (branch.indexOf('--') > -1) { libs = `https://${branch}.${env}.live/libs`; return libs; }
       libs = `https://${branch}--milo--adobecom.${env}.live/libs`;


### PR DESCRIPTION
* Modifies the setLibs conditional into an array that checks the host for specific strings and includes `.stage.` to allow the use of `?milolibs={branch}` on www.stage.adobe.com


**Test URLs:**
- Before: https://main--cc--adobecom.aem.live/creativecloud?martech=off
- After: https://allow-milolibs-on-stage--cc--adobecom.aem.live/creativecloud?martech=off

**Verification**
Verification was done to ensure that milolibs and libs get set as expected on this repository. To check against www.stage.adobe.com local overrides were used before making code changes in the repository.  