### PR TITLE
MWPW-191644: Include "firefly-howto" in iconsExclusionBlocks

### DIFF
--- a/creativecloud/scripts/utils.js
+++ b/creativecloud/scripts/utils.js
@@ -388,7 +388,7 @@ const CONFIG = {
   contentRoot: '/cc-shared',
   codeRoot: '/creativecloud',
   imsClientId: 'adobedotcom-cc',
-  iconsExcludeBlocks: ['unity', 'cc-forms', 'interactive-metadata'],
+  iconsExcludeBlocks: ['unity', 'cc-forms', 'interactive-metadata', 'firefly-howto'],
   locales,
   geoRouting: 'on',
   prodDomains: ['www.adobe.com', 'helpx.adobe.com', 'business.adobe.com'],


### PR DESCRIPTION
* Include "firefly-howto" in iconsExclusionBlocks

> Counterpart Milo PR - https://github.com/adobecom/milo/pull/5767

Resolves: [MWPW-191644](https://jira.corp.adobe.com/browse/MWPW-191644)

**Test URLs:**
- Before: https://main--cc--adobecom.aem.live/products/firefly/features/ai-art-generator?martech=off
- After: https://MWPW-191644-ff-howto--cc--adobecom.aem.live/products/firefly/features/ai-art-generator?martech=off

**Dev validation**
<img width="1874" height="464" alt="before-decorate-icon" src="https://github.com/user-attachments/assets/af0dae86-4763-4531-94f7-6da39439e81c" />
<img width="1847" height="381" alt="after-decorate-icon" src="https://github.com/user-attachments/assets/c5808cf8-a06e-41cd-800e-5987e407acd6" />
