### PR TITLE
[MWPW-190523, MWPW-187015]: [Accessibility] Fix axe devtools and nvda issue.

### DIFF
--- a/creativecloud/blocks/prm-yt-gallery/prm-yt-gallery.css
+++ b/creativecloud/blocks/prm-yt-gallery/prm-yt-gallery.css
@@ -143,7 +143,7 @@
   max-width: calc(100% - var(--button-max-width-offset));
   overflow: hidden;
   text-overflow: ellipsis;
-  opacity: 0;
+  visibility: hidden;
   display: var(--button-display);
 }
 
@@ -171,7 +171,7 @@
   align-items: center;
   justify-content: center;
   z-index: 2;
-  opacity: 0;
+  visibility: hidden;
 }
 
 .pre-yt-card-inner .pre-yt-close-card-button {
@@ -189,6 +189,7 @@
   align-items: center;
   justify-content: center;
   z-index: 4;
+  visibility: hidden;
 }
 
 .pre-yt-card-inner .pre-yt-info-overlay {
@@ -273,8 +274,9 @@
 }
 
 .pre-yt-card.expanded .pre-yt-button,
-.pre-yt-card.expanded .pre-yt-info-button {
-  opacity: 1;
+.pre-yt-card.expanded .pre-yt-info-button,
+.pre-yt-card.expanded .pre-yt-close-card-button {
+  visibility: visible;
 }
 
 .pre-yt-card.expanded .pre-yt-free-tag {
@@ -288,8 +290,7 @@
 
 .pre-yt-card.info-visible .pre-yt-info-button,
 .pre-yt-card.info-visible .pre-yt-close-card-button {
-  opacity: 0;
-  pointer-events: none;
+  visibility: hidden;
 }
 
 .pre-yt-card.info-visible .pre-yt-button {

--- a/creativecloud/blocks/prm-yt-gallery/prm-yt-gallery.js
+++ b/creativecloud/blocks/prm-yt-gallery/prm-yt-gallery.js
@@ -203,12 +203,12 @@ const collapseCard = (card, video) => {
 };
 
 // Creates a reusable close button.
-const createCloseButton = (className, ariaLabel, onClick, tabIndex = 0, ariaHidden = 'false') => {
+const createCloseButton = (className, ariaLabel, onClick, tabindex = 0, ariaHidden = 'false') => {
   const button = createTag('button', {
     class: className,
     'aria-label': ariaLabel,
     type: 'button',
-    tabIndex,
+    tabindex,
     'aria-hidden': ariaHidden,
   });
   button.insertAdjacentHTML('beforeend', ICONS.close);

--- a/creativecloud/blocks/prm-yt-gallery/prm-yt-gallery.js
+++ b/creativecloud/blocks/prm-yt-gallery/prm-yt-gallery.js
@@ -190,7 +190,6 @@ const playVideo = (video) => {
 // Expands a card and starts video playback.
 const expandCard = (card, video) => {
   card.classList.add(CLASSES.EXPANDED);
-  card.setAttribute('aria-expanded', 'true');
   if (video && !card.classList.contains(CLASSES.INFO_VISIBLE)) {
     playVideo(video);
   }
@@ -199,7 +198,6 @@ const expandCard = (card, video) => {
 // Collapses a card and stops video playback.
 const collapseCard = (card, video) => {
   card.classList.remove(CLASSES.EXPANDED, CLASSES.INFO_VISIBLE);
-  card.setAttribute('aria-expanded', 'false');
   card.querySelector(`.${CLASSES.OVERLAY_TEXT}`).scrollTop = 0;
   if (video) video.pause();
 };
@@ -296,7 +294,6 @@ const createShimmerCard = (buttonText) => {
     class: `${CLASSES.CARD} ${CLASSES.SHIMMER}`,
     tabindex: '0',
     role: 'group',
-    'aria-expanded': 'false',
   });
   const cardInner = createTag('div', { class: CLASSES.CARD_INNER });
   const imageWrapper = createTag('div', { class: CLASSES.IMAGE_WRAPPER });

--- a/creativecloud/blocks/prm-yt-gallery/prm-yt-gallery.js
+++ b/creativecloud/blocks/prm-yt-gallery/prm-yt-gallery.js
@@ -37,6 +37,15 @@ const CLASSES = {
   INFO_VISIBLE: 'info-visible',
 };
 
+// Centralized accessible names (aria-label) for the gallery block.
+const ARIA_LABELS = {
+  CARD_LOADING: 'Loading template',
+  CARD_UNAVAILABLE: 'Templates unavailable',
+  SHOW_INFO: 'Show info',
+  CLOSE_CARD: 'Close card',
+  OVERLAY_CLOSE: 'Close text description',
+};
+
 // SVG Icons
 const ICONS = {
   close: `
@@ -232,7 +241,7 @@ const createCloseButton = (className, ariaLabel, onClick, tabindex = 0, ariaHidd
 const createInfoButton = () => {
   const button = createTag('button', {
     class: CLASSES.INFO_BUTTON,
-    'aria-label': 'Show info',
+    'aria-label': ARIA_LABELS.SHOW_INFO,
     type: 'button',
   });
   button.insertAdjacentHTML('beforeend', ICONS.info);
@@ -280,7 +289,7 @@ const createCloseCardButton = (card) => {
   const video = card.querySelector(`.${CLASSES.VIDEO_WRAPPER} video`);
   return createCloseButton(
     CLASSES.CLOSE_CARD_BUTTON,
-    'Close card',
+    ARIA_LABELS.CLOSE_CARD,
     () => {
       collapseCard(card, video);
       if (window.innerWidth > CONFIG.VIEWPORT.mobile) { card?.querySelector('.pre-yt-info-button')?.focus(); }
@@ -294,6 +303,7 @@ const createShimmerCard = (buttonText) => {
     class: `${CLASSES.CARD} ${CLASSES.SHIMMER}`,
     tabindex: '0',
     role: 'group',
+    'aria-label': ARIA_LABELS.CARD_LOADING,
   });
   const cardInner = createTag('div', { class: CLASSES.CARD_INNER });
   const imageWrapper = createTag('div', { class: CLASSES.IMAGE_WRAPPER });
@@ -448,7 +458,7 @@ const setupInfoOverlay = (card) => {
 
   const closeOverlayButton = createCloseButton(
     CLASSES.OVERLAY_CLOSE,
-    'Close text description',
+    ARIA_LABELS.OVERLAY_CLOSE,
     () => {
       hideInfoOverlay(card, video);
       if (window.innerWidth > CONFIG.VIEWPORT.mobile) {
@@ -597,5 +607,9 @@ export default async function init(el) {
   });
   if (data) {
     updateCardsWithData(grid, data, cardLimit, blockProps.freeTagText, blockProps.branchLinkTestId);
+  } else {
+    grid.querySelectorAll(`.${CLASSES.CARD}`).forEach((card) => {
+      card.setAttribute('aria-label', ARIA_LABELS.CARD_UNAVAILABLE);
+    });
   }
 }

--- a/creativecloud/blocks/prm-yt-gallery/prm-yt-gallery.js
+++ b/creativecloud/blocks/prm-yt-gallery/prm-yt-gallery.js
@@ -190,6 +190,7 @@ const playVideo = (video) => {
 // Expands a card and starts video playback.
 const expandCard = (card, video) => {
   card.classList.add(CLASSES.EXPANDED);
+  card.setAttribute('aria-expanded', 'true');
   if (video && !card.classList.contains(CLASSES.INFO_VISIBLE)) {
     playVideo(video);
   }
@@ -198,18 +199,19 @@ const expandCard = (card, video) => {
 // Collapses a card and stops video playback.
 const collapseCard = (card, video) => {
   card.classList.remove(CLASSES.EXPANDED, CLASSES.INFO_VISIBLE);
+  card.setAttribute('aria-expanded', 'false');
   card.querySelector(`.${CLASSES.OVERLAY_TEXT}`).scrollTop = 0;
   if (video) video.pause();
 };
 
 // Creates a reusable close button.
-const createCloseButton = (className, ariaLabel, onClick, tabIndex = 0) => {
+const createCloseButton = (className, ariaLabel, onClick, tabIndex = 0, ariaHidden = 'false') => {
   const button = createTag('button', {
     class: className,
     'aria-label': ariaLabel,
     type: 'button',
     tabIndex,
-    'aria-hidden': 'true',
+    'aria-hidden': ariaHidden,
   });
   button.insertAdjacentHTML('beforeend', ICONS.close);
   button.addEventListener('click', (e) => {
@@ -234,8 +236,6 @@ const createInfoButton = () => {
     class: CLASSES.INFO_BUTTON,
     'aria-label': 'Show info',
     type: 'button',
-    tabindex: '0',
-    'aria-hidden': 'true',
   });
   button.insertAdjacentHTML('beforeend', ICONS.info);
   return button;
@@ -243,18 +243,17 @@ const createInfoButton = () => {
 
 // Creates the "Edit this template" button.
 const createEditButton = (buttonText) => {
-  const button = createTag('a', {
-    class: CLASSES.BUTTON,
-    tabindex: '0',
-    'aria-hidden': 'true',
-  });
+  const button = createTag('a', { class: CLASSES.BUTTON });
   button.textContent = buttonText;
   return button;
 };
 
 // Creates the info overlay with text container.
 const createInfoOverlay = () => {
-  const overlay = createTag('div', { class: CLASSES.INFO_OVERLAY });
+  const overlay = createTag('div', {
+    class: CLASSES.INFO_OVERLAY,
+    'aria-hidden': 'true',
+  });
   const overlayText = createTag('p', { class: CLASSES.OVERLAY_TEXT, tabindex: '-1' });
   overlay.append(overlayText);
   return overlay;
@@ -296,7 +295,8 @@ const createShimmerCard = (buttonText) => {
   const card = createTag('div', {
     class: `${CLASSES.CARD} ${CLASSES.SHIMMER}`,
     tabindex: '0',
-    role: 'presentation',
+    role: 'group',
+    'aria-expanded': 'false',
   });
   const cardInner = createTag('div', { class: CLASSES.CARD_INNER });
   const imageWrapper = createTag('div', { class: CLASSES.IMAGE_WRAPPER });
@@ -349,19 +349,15 @@ const updateCardWithData = (card, item, eager = false) => {
   const img = createImageElement(item.image, eager);
   handleImageLoad(card, img);
   imageWrapper.append(img);
-  const overlayTextId = `overlay-text-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
 
   // Update overlay text
   if (overlayText) {
     overlayText.textContent = item.altText;
-    overlayText.ariaLive = 'polite';
-    overlayText.id = overlayTextId;
   }
 
-  // Update button deep link and aria-describedby
+  // Update button deep link URL
   if (button && item.deepLinkUrl) {
     button.href = item.deepLinkUrl;
-    button.setAttribute('aria-describedby', overlayTextId);
   }
 
   // Add video if available
@@ -373,6 +369,10 @@ const updateCardWithData = (card, item, eager = false) => {
 // Shows info overlay and pauses video.
 const showInfoOverlay = (card, video, closeOverlayButton) => {
   card.classList.add(CLASSES.INFO_VISIBLE);
+  const infoOverlay = card.querySelector(`.${CLASSES.INFO_OVERLAY}`);
+  if (infoOverlay) {
+    infoOverlay.setAttribute('aria-hidden', 'false');
+  }
   if (video) video.pause();
   if (closeOverlayButton) {
     closeOverlayButton.tabindex = 0;
@@ -384,6 +384,10 @@ const showInfoOverlay = (card, video, closeOverlayButton) => {
 // Hides info overlay and resumes video.
 const hideInfoOverlay = (card, video) => {
   card.classList.remove(CLASSES.INFO_VISIBLE);
+  const infoOverlay = card.querySelector(`.${CLASSES.INFO_OVERLAY}`);
+  if (infoOverlay) {
+    infoOverlay.setAttribute('aria-hidden', 'true');
+  }
   setAriaHidden(`.${CLASSES.OVERLAY_CLOSE}`, true, card);
   if (video) {
     video.play().catch((error) => {
@@ -457,6 +461,7 @@ const setupInfoOverlay = (card) => {
       }
     },
     -1,
+    'true',
   );
   overlay.appendChild(closeOverlayButton);
 


### PR DESCRIPTION
- Improved screen reader and keyboard behaviour for the Premiere YouTube template gallery block: clearer roles and state, less duplicate or missing announcements, and controls that stay in the accessibility tree when appropriate. CSS is updated so hidden controls use `visibility` instead of `opacity`, which plays better with assistive tech and focus.
- Inner card buttons are reachable with `Tab` after the card is focused. `Shift+Tab` does not step into those controls when moving backward, use `Tab` to enter them.
- Handled loading: Shimmer cards show “Loading template” until data returns; then labels update to real titles, “No template” for unused slots, or “Templates unavailable” on failure.
- Handled duplicate announcements (NVDA): Adjusted aria-describedby (and related wiring) so NVDA doesn’t repeat the same template title when moving focus—users still get the full context without redundant speech.

Resolves: [MWPW-190523](https://jira.corp.adobe.com/browse/MWPW-190523), [MWPW-187015](https://jira.corp.adobe.com/browse/MWPW-187015)

**Test URLs:**
- Before: https://main--cc--adobecom.aem.live/?martech=off
- After: https://mwpw-190523-a11y-axe--cc--adobecom.aem.live/products/premiere/app/youtube?martech=off

**Dev validation:**

- Before(Desktop, Tablet, Mobile):- 

<img width="1512" height="814" alt="before-fix-desktop" src="https://github.com/user-attachments/assets/7c8dda52-c1f7-465a-974e-b3976e812224" />
<img width="1512" height="814" alt="before-fix-tablet" src="https://github.com/user-attachments/assets/202b1cbb-5432-4dac-a0f3-4727cdb02072" />
<img width="1512" height="814" alt="before-fix-mobile" src="https://github.com/user-attachments/assets/1b9a194e-ac16-4401-9730-f9ef2b55a6f7" />

- Before Loading state:-
<img width="1503" height="738" alt="before-fix" src="https://github.com/user-attachments/assets/e238e68e-3655-474a-859d-1f64f3f25cc2" />

- Before Duplicate announcement:- 
<img width="1503" height="738" alt="before-fix" src="https://github.com/user-attachments/assets/b95681e3-0dfd-4cfb-897c-08e73435ff58" />


- After(Desktop, Tablet, Mobile):- 
<img width="1512" height="814" alt="after-fix-desktop" src="https://github.com/user-attachments/assets/6117940a-3655-4740-99cc-80ba70d9eeee" />
<img width="1512" height="814" alt="after-fix-tablet" src="https://github.com/user-attachments/assets/2d3657cb-7fb1-4024-85bc-9044d6b3ba17" />
<img width="1512" height="814" alt="after-fix-mobile" src="https://github.com/user-attachments/assets/570060f0-5272-485a-ac9c-83adf79aef7e" />

- After Loading state:-
<img width="1503" height="738" alt="after-fix" src="https://github.com/user-attachments/assets/f15449c3-faf1-4666-a0ef-4f139368ab4b" />

- After Duplicate announcement:- 
<img width="1503" height="738" alt="after-fix" src="https://github.com/user-attachments/assets/4b25c36a-3ff8-41c9-b6e7-cc2119057a37" />