### PR TITLE
[MWPW-191327] Fix for Text overlapping issue in upload-marquee for international locales

### DIFF
--- a/creativecloud/blocks/upload-marquee/upload-marquee.css
+++ b/creativecloud/blocks/upload-marquee/upload-marquee.css
@@ -227,9 +227,13 @@
   font-size: 40px;
   font-style: normal;
   font-weight: 800;
-  line-height: 98%;
+  line-height: 125%;
   letter-spacing: -1.8px;
   margin-bottom: 16px;
+}
+
+:root:lang(en) .upload-marquee-block .upload-marquee-layout .upload-marquee-left .upload-marquee-content h1 {
+  line-height: 98%;
 }
 
 .upload-marquee-block .upload-marquee-layout .upload-marquee-left .upload-marquee-content p {


### PR DESCRIPTION
 Fix for Text overlapping issue in upload-marquee for international locales

Resolves: [MWPW-191327](https://jira.corp.adobe.com/browse/MWPW-191327)

**Test URLs:**
- Before: https://main--cc--adobecom.aem.page/in_hi/products/firefly/features/remove-person-from-photo
- After: https://mwpw-191327--cc--adobecom.aem.page/in_hi/products/firefly/features/remove-person-from-photo
