### PR TITLE
[MWPW-190530]: [Accessibility] Added white focus ring on interactive buttons.

### DIFF
--- a/creativecloud/blocks/interactive-metadata/interactive-metadata.css
+++ b/creativecloud/blocks/interactive-metadata/interactive-metadata.css
@@ -264,6 +264,11 @@
   background: var(--prompt-btn-fill-light);
 } 
 
+/* WCAG 1.4.11: extra ring outside blue border (keyboard focus only). */
+.interactive-enabled .layer .gray-button:focus-visible {
+  box-shadow: 0 0 0 2px #fff;
+}
+
 .interactive-enabled .interactive-link-analytics-text {
   display: none;
 }
@@ -412,6 +417,10 @@
     font-size: var(--type-body-xl-size); 
     line-height: var(--type-body-xl-lh);
     box-shadow: 0 10px 10px rgba(0, 0, 0, 32%);
+  }
+
+  .interactive-enabled .layer .gray-button:focus-visible {
+    box-shadow: 0 0 0 2px #fff, 0 10px 10px rgba(0, 0, 0, 32%);
   }
 
   .interactive-enabled .layer .gray-button.animated::before {

--- a/creativecloud/blocks/interactive-metadata/interactive-metadata.css
+++ b/creativecloud/blocks/interactive-metadata/interactive-metadata.css
@@ -266,7 +266,7 @@
 
 /* WCAG 1.4.11: extra ring outside blue border (keyboard focus only). */
 .interactive-enabled .layer .gray-button:focus-visible {
-  box-shadow: 0 0 0 2px #fff;
+  box-shadow: 0 0 0 2px var(--prompt-btn-fill-light);
 }
 
 .interactive-enabled .interactive-link-analytics-text {
@@ -420,7 +420,7 @@
   }
 
   .interactive-enabled .layer .gray-button:focus-visible {
-    box-shadow: 0 0 0 2px #fff, 0 10px 10px rgba(0, 0, 0, 32%);
+    box-shadow: 0 0 0 2px var(--prompt-btn-fill-light), 0 10px 10px rgba(0, 0, 0, 32%);
   }
 
   .interactive-enabled .layer .gray-button.animated::before {


### PR DESCRIPTION
* Added a white outer focus ring on buttons so the focus indicator satisfies 3:1 contrast for accessibility.

Resolves: [MWPW-190530](https://jira.corp.adobe.com/browse/MWPW-190530)

**Test URLs:**
- Before: https://main--cc--adobecom.aem.live/drafts/himani/illustrator-a11y?martech=off
- After: https://mwpw-190530-a11y-contrast-ratio--cc--adobecom.aem.live/drafts/himani/illustrator-a11y?martech=off

**Dev Validation:**

- Before:-

<img width="1508" height="744" alt="before-fix-generate" src="https://github.com/user-attachments/assets/2f87bcbc-ce56-41bb-a34a-a78dc16b4a6f" />

<img width="1508" height="795" alt="before-fix-startover" src="https://github.com/user-attachments/assets/c99d2d58-4df0-4eab-ade7-227936a5df99" />

- After:-

<img width="1508" height="744" alt="after-fix-generate" src="https://github.com/user-attachments/assets/a8a2f5b3-bc40-4af6-813a-7347b5be3a97" />

<img width="1508" height="744" alt="after-fix-startover" src="https://github.com/user-attachments/assets/0487b761-7a6d-4679-873c-f7f955d0bfdf" />