### PR TITLE
[MWPW-191054] - Bump catalog-marquee includes-section titles to XS font size

### DIFF
--- a/creativecloud/plans/blocks/catalog-marquee/catalog-marquee.css
+++ b/creativecloud/plans/blocks/catalog-marquee/catalog-marquee.css
@@ -136,6 +136,10 @@
     display: block;
     margin: 0 0 var(--spacing-s);
   }
+
+  .catalog-marquee .mnemonic-list .product-list .product-item strong {
+    font-size: var(--type-heading-xs-size);
+  }
 }
 
 @media screen and (min-width: 1600px) {


### PR DESCRIPTION
Closes https://jira.corp.adobe.com/browse/MWPW-191054

## Summary
- Bump the font size of product titles inside `.catalog-marquee .mnemonic-list` from XXS (~11px) to XS (~18px) for improved readability and accessibility
- Scoped to `.catalog-marquee` so milo's `mnemonic-list` defaults remain unchanged for other consumers (merch-card, marquee, etc.)
- Added inside the existing `@media (min-width: 1200px)` block where the mnemonic-list is set to `display: block`, so the rule lives next to the visibility rule it relates to

## Test URLs:

- Before: https://main--cc--adobecom.aem.page/fr/products/catalog?martech=off
- After: https://mwpw-191054--cc--adobecom.aem.page/fr/products/catalog?martech=off
- Before (NL): https://main--cc--adobecom.aem.page/nl/products/catalog?martech=off
- After (NL): https://mwpw-191054--cc--adobecom.aem.page/nl/products/catalog?martech=off