### PR TITLE
Fix stale interactive-components and cc-forms paths broken by plans/ reorg

### DIFF
--- a/creativecloud/plans/blocks/cc-forms/cc-forms.js
+++ b/creativecloud/plans/blocks/cc-forms/cc-forms.js
@@ -22,7 +22,7 @@ const odinConfig = {
 const formConfig = {
   perpeptual: {
     type: 'perpeptual',
-    jsPath: '/creativecloud/features/cc-forms/forms/perpeptual.js',
+    jsPath: '/creativecloud/plans/features/cc-forms/forms/perpeptual.js',
     blockDataset: {
       clientname: 'trials',
       endpoint: '/api2/marketing_common_service',
@@ -33,7 +33,7 @@ const formConfig = {
   },
   connect: {
     type: 'connect',
-    jsPath: '/creativecloud/features/cc-forms/forms/connect.js',
+    jsPath: '/creativecloud/plans/features/cc-forms/forms/connect.js',
     blockDataset: {
       clientname: 'connecttrial',
       endpoint: '/api2/connect_trial_creation_service',
@@ -47,7 +47,7 @@ const formConfig = {
   },
   subscribe: {
     type: 'subscribe',
-    jsPath: '/creativecloud/features/cc-forms/forms/subscribe.js',
+    jsPath: '/creativecloud/plans/features/cc-forms/forms/subscribe.js',
     blockDataset: {
       endpoint: '/api2/subscribe_v1',
       'form-submit': 'trials',
@@ -60,7 +60,7 @@ const formConfig = {
   },
   unsubscribe: {
     type: 'unsubscribe',
-    jsPath: '/creativecloud/features/cc-forms/forms/unsubscribe.js',
+    jsPath: '/creativecloud/plans/features/cc-forms/forms/unsubscribe.js',
     blockDataset: {
       clientname: 'trials',
       endpoint: '/api2/unsubscribe_v2',

--- a/creativecloud/plans/blocks/interactive-metadata/interactive-metadata.js
+++ b/creativecloud/plans/blocks/interactive-metadata/interactive-metadata.js
@@ -39,8 +39,8 @@ async function addLayerAnimation(asset) {
 }
 
 async function loadJSandCSS(stepName) {
-  const stepJS = `${window.location.origin}/creativecloud/features/interactive-components/${stepName}/${stepName}.js`;
-  const stepCSS = `${window.location.origin}/creativecloud/features/interactive-components/${stepName}/${stepName}.css`;
+  const stepJS = `${window.location.origin}/creativecloud/plans/features/interactive-components/${stepName}/${stepName}.js`;
+  const stepCSS = `${window.location.origin}/creativecloud/plans/features/interactive-components/${stepName}/${stepName}.css`;
   loadStyle(stepCSS);
   const { default: initFunc } = await import(stepJS);
   return initFunc;


### PR DESCRIPTION
## Description

Correcting missing path updates updates from https://github.com/adobecom/cc/pull/980 

These fixes unblock my original PR https://github.com/adobecom/cc/pull/983

URL just for the PSI Check to pass: https://fix-plans-feature-paths--cc--adobecom.aem.page/