### PR TITLE
MWPW-200482 - Remove JIRA Epic field from .kodiak config

### DIFF
--- a/.kodiak/config.yaml
+++ b/.kodiak/config.yaml
@@ -16,7 +16,6 @@ notifications:
       fields:
         assignee:
           name: sumanh
-        customfield_11800: MWPW-164516 #epic link
         customfield_12900: 
           value: Brahmos
         watchers:


### PR DESCRIPTION
Removing JIRA Epic field from .kodiak/config.yaml

Test URLs:

Before: https://main--cc--adobecom.aem.live/?martech=off
After: https://mwpw-200482--cc--adobecom.aem.live/?martech=off